### PR TITLE
Using the env values for admin & platformOperator logic.

### DIFF
--- a/scripts/BuildNuance.sh
+++ b/scripts/BuildNuance.sh
@@ -194,10 +194,6 @@ userCanisterId="$(grep -A2 '"User"' $canisterFilePath | grep $network | grep -o 
 echo "User Canister id: $userCanisterId"
 echo ""
 
-echo "Getting Post canister Id to register as admin of PostIndex canister"
-postCanisterId="$(grep -A2 '"Post"' $canisterFilePath | grep $network | grep -o '[A-Za-z0-9\-]\{27\}')"
-echo "Post Canister id: $postCanisterId"
-echo ""
 
 echo "Getting PostCore canister Id to register as admin of PostIndex canister"
 postCoreCanisterId="$(grep -A2 '"PostCore"' $canisterFilePath | grep $network | grep -o '[A-Za-z0-9\-]\{27\}')"
@@ -220,94 +216,12 @@ assetCanisterId="$(grep -A2 '"nuance_assets"' $canisterFilePath | grep $network 
 echo "nuance_assets Canister id: $assetCanisterId"
 echo ""
 
-echo "Registering admins for KinicEndpoint canister"
-dfx canister --network $network call KinicEndpoint registerAdmin "$defaultPrincipal"
-dfx canister --network $network call KinicEndpoint registerAdmin "$userCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call KinicEndpoint registerAdmin "$p"
-done
 
-echo "Registering admins for Post canister"
-dfx canister --network $network call Post registerAdmin "$defaultPrincipal"
-dfx canister --network $network call Post registerAdmin "$userCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call Post registerAdmin "$p"
-done
-
-echo "Registering admins for PostCore canister"
-dfx canister --network $network call PostCore registerAdmin "$defaultPrincipal"
-dfx canister --network $network call PostCore registerAdmin "$userCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call PostCore registerAdmin "$p"
-done
-dfx canister --network $network call PostCore getAdmins
-echo ""
-
-echo "Registering admins for CyclesDispenser canister"
-dfx canister --network $network call CyclesDispenser registerAdmin "$defaultPrincipal"
+echo "Registering Canisters for CyclesDispenser canister"
 dfx canister --network $network call CyclesDispenser registerCanister "$postCoreCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call CyclesDispenser registerAdmin "$p"
-done
-dfx canister --network $network call CyclesDispenser getAdmins
+dfx canister --network $network call CyclesDispenser getTrustedCanisters
 echo ""
 
-echo "Registering admins for PostIndex canister"
-dfx canister --network $network call PostIndex registerAdmin "$defaultPrincipal"
-dfx canister --network $network call PostIndex registerAdmin "$postCanisterId"
-dfx canister --network $network call PostIndex registerAdmin "$postCoreCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call PostIndex registerAdmin "$p"
-done
-dfx canister --network $network call PostIndex getAdmins
-echo ""
-
-echo "Registering admins for User canister"
-dfx canister --network $network call User registerAdmin "$defaultPrincipal"
-dfx canister --network $network call User registerAdmin "$postCanisterId"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call User registerAdmin "$p"
-done
-dfx canister --network $network call User getAdmins
-echo ""
-
-echo "Registering admins for Storage canister"
-dfx canister --network $network call Storage registerAdmin "$defaultPrincipal"
-for p in "${userPrincipals[@]}"
-do
-    dfx canister --network $network call Storage registerAdmin "$p"
-done
-dfx canister --network $network call User getAdmins
-echo ""
-
-echo "Initializing the KinicEndpoint canister"
-dfx canister --network $network call KinicEndpoint initializeCanister '("'$postCoreCanisterId'")'
-
-echo "Initializing the Post canister"
-dfx canister --network $network call Post initializeCanister '("'$postIndexCanisterId'", "'$userCanisterId'")'
-
-echo "Initializing the PostCore canister"
-dfx canister --network $network call PostCore initializeCanister '("'$postIndexCanisterId'", "'$userCanisterId'", "'$cyclesDispenserCanisterId'")'
-
-
-echo "Setting up Nuance as data provider to modclub"
-dfx canister --network $network call Post setUpModClub staging
-echo "Modclub Set up Completed"
-
-echo "Registering Users for Canistergeek (Post Canister)"
-
-for c in "${cgUserPrincipals[@]}"
-do
-dfx canister --network $network call Post registerCgUser "$c"
-done
-dfx canister --network $network call Post getCgUsers
-echo ""
 
 echo "Registering Users for Canistergeek (PostIndex Canister)"
 
@@ -362,8 +276,6 @@ echo "AUTHORIZE PostCore as admin to nuance_assets"
 echo ""
 dfx canister --network $network call nuance_assets authorize '(principal "'$postCoreCanisterId'")'
 dfx canister --network $network update-settings nuance_assets --add-controller $postCoreCanisterId
-dfx canister --network $network call PostCore setFrontendCanisterId '("'$assetCanisterId'")'
-
 echo "Completed!"
 
 #endregion

--- a/scripts/DevInstall.sh
+++ b/scripts/DevInstall.sh
@@ -124,10 +124,7 @@ echo "##### Cycles Dispenser setup #####"
 echo ""
 dfx canister call Storage uploadBlob '(record { contentId = ""; chunkData = vec {}; offset = 0; totalChunks = 0; mimeType = ""; contentSize = 0; })'
 node ./scripts/GetAllCanisterIds.js -CyclesDispenser
-node ./scripts/adminAll.js registerAdmin $(dfx identity get-principal)
-node ./scripts/adminAll.js registerAdmin $(dfx canister id CyclesDispenser)
 node ./scripts/cyclesDispenserAdd.js -devInstall
-dfx canister call CyclesDispenser batchRegisterAdmin '(principal "'$(dfx identity get-principal --identity nuance-identity-admin)'")'
 
 echo ""
 echo "##### Initialize Nuance Canisters for Metrics canister #####"

--- a/scripts/buildPublications.sh
+++ b/scripts/buildPublications.sh
@@ -82,7 +82,6 @@ dfx canister --network $network call $postCoreCanisterId registerAdmin '("'$publ
 echo ""
 echo "Initializing the PublicationManagement canister"
 echo ""
-dfx canister --network $network call PublicationManagement initializeCanister '("'$postCoreCanisterId'", "'$userCanisterId'", "'$nftFactoryCanisterId'")'
 dfx canister --network $network call PublicationManagement initManagementCanister
 
 

--- a/src/CyclesDispenser/main.mo
+++ b/src/CyclesDispenser/main.mo
@@ -296,7 +296,7 @@ actor CyclesDispenser {
       return #err("Canister reached the maximum memory threshold. Please try again later.");
     };
 
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -312,7 +312,7 @@ actor CyclesDispenser {
       return #err("Cannot use this method anonymously.");
     };
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/CyclesDispenser/main.mo
+++ b/src/CyclesDispenser/main.mo
@@ -15,6 +15,7 @@ import Buffer "mo:base/Buffer";
 import Float "mo:base/Float";
 import Prim "mo:prim";
 import Versions "../shared/versions";
+import ENV "../shared/env";
 
 actor CyclesDispenser {
   let maxHashmapSize = 1000000;
@@ -119,12 +120,6 @@ actor CyclesDispenser {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
   };
 
-  private func isAdmin(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
-
   private func isCanisterItself(caller : Principal) : Bool {
     Principal.equal(caller, Principal.fromActor(CyclesDispenser));
   };
@@ -133,14 +128,6 @@ actor CyclesDispenser {
     var c = Principal.toText(caller);
     var exists = List.find<Text>(nuanceCanisters, func(val : Text) : Bool { val == c });
     exists != null;
-  };
-
-  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    #ok(List.toArray(admins));
   };
 
   public shared ({ caller }) func batchRegisterAdmin(admin : Principal) : async Result.Result<[Text], Text> {
@@ -243,40 +230,6 @@ actor CyclesDispenser {
 
   };
 
-  //platform operators, similar to admins but restricted to a few functions
-
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
-  };
-
-  private func isPlatformOperator(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
-
   public shared query ({ caller }) func getTrustedCanisters() : async Result.Result<[Text], Text> {
     /*if (not isAdmin(caller)) {
             return #err(Unauthorized);
@@ -306,7 +259,7 @@ actor CyclesDispenser {
       return #err("Canister reached the maximum memory threshold. Please try again later.");
     };
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     if (not List.some<Text>(nuanceCanisters, func(val : Text) : Bool { val == id })) {
@@ -369,37 +322,43 @@ actor CyclesDispenser {
     return Principal.fromActor(CyclesDispenser);
   };
 
-  //This function should be invoked immediately after the canister is deployed via script.
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+  private func isAdmin(caller : Principal) : Bool {
+    var c = Principal.toText(caller);
+    U.arrayContains(ENV.CYCLES_DISPENSER_CANISTER_ADMINS, c);
+  };
+
+  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
     if (isAnonymous(caller)) {
       return #err("Cannot use this method anonymously.");
     };
 
-    if (not isThereEnoughMemoryPrivate()) {
-      return #err("Canister reached the maximum memory threshold. Please try again later.");
-    };
+    #ok(ENV.CYCLES_DISPENSER_CANISTER_ADMINS);
+  };
 
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
+  private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
 
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
-    };
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
 
-    #ok();
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
   };
 
   public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
+    #err("Deprecated function")
+  };
 
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
-    #ok();
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
   };
 
   //#region top-up management
@@ -442,7 +401,7 @@ actor CyclesDispenser {
       return #err("Canister reached the maximum memory threshold. Please try again later.");
     };
 
-    if (not isAdmin(caller) and not isNuanceCanister(caller)) {
+    if (not isAdmin(caller) and not isNuanceCanister(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 

--- a/src/KinicEndpoint/main.mo
+++ b/src/KinicEndpoint/main.mo
@@ -20,6 +20,7 @@ import Cycles "mo:base/ExperimentalCycles";
 import Prim "mo:prim";
 import CanisterDeclarations "../shared/CanisterDeclarations";
 import Versions "../shared/versions";
+import ENV "../shared/env";
 
 actor KinicEndpoint {
   // local variables
@@ -57,7 +58,6 @@ actor KinicEndpoint {
   stable var cgusers : List.List<Text> = List.nil<Text>();
   stable var kinicPrincipals : List.List<Text> = List.nil<Text>();
 
-  stable var postCoreCanisterId = "";
   stable var index : [(Text, [Text])] = [];
   var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
 
@@ -65,54 +65,10 @@ actor KinicEndpoint {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
   };
 
-  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    #ok(List.toArray(admins));
-  };
-
-  //platform operators, similar to admins but restricted to a few functions
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
-  };
-
-  private func isPlatformOperator(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
-
   //initialize method to store the canister ids that this canister interacts with
+  //deprecated
   public shared ({ caller }) func initializeCanister(postCoreCai : Text) : async Result.Result<Text, Text> {
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    postCoreCanisterId := postCoreCai;
-    #ok(postCoreCanisterId);
+    #err("Deprecated function.")
   };
 
   // admin and canister functions
@@ -158,41 +114,6 @@ actor KinicEndpoint {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    if (not isThereEnoughMemoryPrivate()) {
-      return #err("Canister reached the maximum memory threshold. Please try again later.");
-    };
-
-    let principalFromText = Principal.fromText(id);
-
-    canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-    canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
     #ok();
   };
 
@@ -249,8 +170,41 @@ actor KinicEndpoint {
 
   private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
+    U.arrayContains(ENV.KINIC_ENDPOINT_CANISTER_ADMINS, c);
+  };
+
+  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
+    if (isAnonymous(caller)) {
+      return #err("Cannot use this method anonymously.");
+    };
+
+    #ok(ENV.KINIC_ENDPOINT_CANISTER_ADMINS);
+  };
+
+  private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
+
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
+
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
   };
 
   func isCgUser(caller : Principal) : Bool {
@@ -264,7 +218,7 @@ actor KinicEndpoint {
     if (isAnonymous(caller)) {
       return #err("Cannot use this method anonymously.");
     };
-    let PostCoreCanister = CanisterDeclarations.getPostCoreCanister(postCoreCanisterId);
+    let PostCoreCanister = CanisterDeclarations.getPostCoreCanister();
     var list : KinicReturn = await PostCoreCanister.getKinicList();
     if (not isKinicPrincipal(caller)) {
       return #err(NotTrustedPrincipal);

--- a/src/KinicEndpoint/main.mo
+++ b/src/KinicEndpoint/main.mo
@@ -94,7 +94,7 @@ actor KinicEndpoint {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -110,7 +110,7 @@ actor KinicEndpoint {
       return #err("Cannot use this method anonymously.");
     };
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/PostBucket/main.mo
+++ b/src/PostBucket/main.mo
@@ -482,7 +482,7 @@ actor class PostBucket() = this {
     let principalFromText = Principal.fromText(id);
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -499,7 +499,7 @@ actor class PostBucket() = this {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/PostBucket/main.mo
+++ b/src/PostBucket/main.mo
@@ -23,6 +23,7 @@ import Prelude "mo:base/Prelude";
 import Cycles "mo:base/ExperimentalCycles";
 import CanisterDeclarations "../shared/CanisterDeclarations";
 import Versions "../shared/versions";
+import ENV "../shared/env";
 
 actor class PostBucket() = this {
   let canistergeekMonitor = Canistergeek.Monitor();
@@ -70,9 +71,6 @@ actor class PostBucket() = this {
   type NftCanisterEntry = Types.NftCanisterEntry;
 
   type Order = { #less; #equal; #greater };
-
-  type FrontendInterface = Types.FrontendInterface;
-  type PostCoreInterface = Types.PostCoreInterface;
 
   type PostSaveModelBucketMigration = Types.PostSaveModelBucketMigration;
 
@@ -125,10 +123,6 @@ actor class PostBucket() = this {
   stable var nftCanisterIds : [(Text, Text)] = [];
   stable var testEntries : [(Text, Text)] = [];
   stable var rejectedByModclubPostIdsEntries : [(Text, Text)] = [];
-  stable var frontendCanisterId : Text = "frontend";
-  stable var postCoreCanisterId : Text = "post-core";
-  stable var postIndexCanisterId = "";
-  stable var userCanisterId = "";
 
   //comment data
   stable var postIdToCommentIdsEntries : [(Text, [Text])] = [];
@@ -240,20 +234,13 @@ actor class PostBucket() = this {
     if (isAnonymous(caller)) {
       return #err("Anonymous user cannot initialize bucket canister");
     };
-
     let _isCallerOwner = await isCallerOwner(caller);
     Debug.print("PostBucket -> initializeBucketCanister");
     Debug.print("isCallerOwner-> " # Bool.toText(_isCallerOwner));
     if (_isCallerOwner or isAdmin(caller)) {
       if (List.size(admins) == 0) {
-        postCoreCanisterId := initPostCoreCanisterId;
-
-        admins := List.push(postCoreCanisterId, List.fromArray(adminsInitial));
         cgusers := List.fromArray(cgUsersInitial);
-        nuanceCanisters := List.push(postCoreCanisterId, List.fromArray(nuanceCanistersInitial));
-        frontendCanisterId := initFrontendCanisterId;
-        postIndexCanisterId := initPostIndexCanisterId;
-        userCanisterId := initUserCanisterId;
+        nuanceCanisters := List.push(initPostCoreCanisterId, List.fromArray(nuanceCanistersInitial));
         for (nftCanisterEntry in nftCanistersInitial.vals()) {
           nftCanisterIdsHashmap.put(nftCanisterEntry.0, nftCanisterEntry.1);
         };
@@ -265,22 +252,17 @@ actor class PostBucket() = this {
     };
 
   };
-
+  //deprecated function
   public shared ({ caller }) func initializeCanister(postIndexCai : Text, userCai : Text) : async Result.Result<Text, Text> {
-    if (not isAdmin(caller) and Principal.toText(caller) != postCoreCanisterId) {
-      return #err(Unauthorized);
-    };
-    postIndexCanisterId := postIndexCai;
-    userCanisterId := userCai;
-    #ok(postIndexCanisterId # ", " # userCanisterId);
+    #err("Deprecated function.")
   };
 
   public shared query func getFrontendCanisterId() : async Text {
-    frontendCanisterId;
+    ENV.NUANCE_ASSETS_CANISTER_ID;
   };
 
   public shared query func getPostCoreCanisterId() : async Text {
-    postCoreCanisterId;
+    ENV.POST_CORE_CANISTER_ID;
   };
 
   public shared query func getBucketCanisterVersion() : async Text {
@@ -346,7 +328,7 @@ actor class PostBucket() = this {
     if (isAnonymous(caller)) {
       return #err("Anonymous user cannot run this method");
     };
-    if (not Principal.equal(caller, Principal.fromText(postCoreCanisterId))) {
+    if (not isAdmin(caller)) {
       return #err(Unauthorized);
     };
     isActive := false;
@@ -387,8 +369,41 @@ actor class PostBucket() = this {
 
   private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
+    U.arrayContains(ENV.POSTBUCKET_CANISTER_ADMINS, c);
+  };
+
+  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
+    if (isAnonymous(caller)) {
+      return #err("Cannot use this method anonymously.");
+    };
+
+    #ok(ENV.POSTBUCKET_CANISTER_ADMINS);
+  };
+
+  private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
+
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
+
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
   };
 
   func isNuanceCanister(caller : Principal) : Bool {
@@ -397,47 +412,6 @@ actor class PostBucket() = this {
     exists != null;
   };
 
-  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-    if (isAnonymous(caller)) {
-      return #err(Unauthorized);
-    };
-
-    #ok(List.toArray(admins));
-  };
-
-  //platform operators, similar to admins but restricted to a few functions
-
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
-  };
-
-  private func isPlatformOperator(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
 
   public shared query ({ caller }) func getTrustedCanisters() : async Result.Result<[Text], Text> {
     /*if (not isAdmin(caller)) {
@@ -460,7 +434,7 @@ actor class PostBucket() = this {
       return #err(Unauthorized);
     };
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -529,44 +503,6 @@ actor class PostBucket() = this {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  //This function should be invoked immediately after the canister is deployed via script.
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Anonymous user cannot run this method");
-    };
-
-    if (not isThereEnoughMemoryPrivate()) {
-      return #err("Canister reached the maximum memory threshold. Please try again later.");
-    };
-
-    //validate input
-    let principalFromText = Principal.fromText(id);
-
-    canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Anonymous user cannot run this method");
-    };
-
-    canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
     #ok();
   };
 
@@ -644,7 +580,7 @@ actor class PostBucket() = this {
             let size = postIdsArray.size();
             let chunkCount = size / 20 + 1;
             var iter = 0;
-            let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+            let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
             var indexingArguments = Buffer.Buffer<CanisterDeclarations.IndexPostModel>(0);
             while (iter < chunkCount) {
               let chunkPostIds = U.filterArrayByIndexes(iter * 20, (iter + 1) * 20, postIdsArray);
@@ -984,7 +920,7 @@ actor class PostBucket() = this {
         var callerHandle = U.safeGet(handleHashMap, userPrincipalId, "");
 
         if (Text.equal(callerHandle, "")) {
-          let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+          let UserCanister = CanisterDeclarations.getUserCanister();
           var user : ?User = await UserCanister.getUserInternal(userPrincipalId);
           switch (user) {
             case (?user) {
@@ -1162,7 +1098,7 @@ actor class PostBucket() = this {
     if (U.safeGet(isPremiumHashMap, postId, false)) {
       return #err(ArticleNotEditable);
     };
-    let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+    let UserCanister = CanisterDeclarations.getUserCanister();
     let user = await UserCanister.getUserByPrincipalId(Principal.toText(caller));
     var userHandle = "";
     var isEditor = false;
@@ -1191,7 +1127,7 @@ actor class PostBucket() = this {
     };
 
     Debug.print("PostBucket->MigratePostToPublication: " # postId);
-    let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+    let postCoreActor = CanisterDeclarations.getPostCoreCanister();
     //make the post publication post in PostCore canister
     await postCoreActor.makePostPublication(postId, publicationHandle, userHandle, isDraft);
     await makePostPublication(postId, publicationHandle, userHandle, isDraft);
@@ -1231,7 +1167,7 @@ actor class PostBucket() = this {
 
     //if the publication canister id is not stored in the bucket canister, fetch it from user canister and store it first.
     if (publicationPrincipalId == "") {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       let userReturn = await UserCanister.getPrincipalByHandle(U.lowerCase(publicationHandle));
       switch (userReturn) {
         case (#ok(principal)) {
@@ -1338,7 +1274,7 @@ actor class PostBucket() = this {
     if (not isPublication and postModel.creator != "") {
       return #err(Unauthorized);
     };
-    let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+    let postCoreActor = CanisterDeclarations.getPostCoreCanister();
 
     let principalId = Principal.toText(caller);
     var savedCreatedDate : Int = 0;
@@ -1374,7 +1310,7 @@ actor class PostBucket() = this {
     // retrieve user handle if it's not already mapped to the principalId
     var userHandle = U.safeGet(handleHashMap, principalId, "");
     if (userHandle == "") {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       var user : ?User = await UserCanister.getUserInternal(principalId);
       switch (user) {
         case (null) return #err("cross canister User not found");
@@ -1392,7 +1328,7 @@ actor class PostBucket() = this {
     //check if the given creator is valid - only for publication posts
     let creatorHandle = U.safeGet(handleHashMap, postModel.creator, "");
     if (creatorHandle == "" and isPublication) {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       var user : ?User = await UserCanister.getUserInternal(postModel.creator);
       switch (user) {
         case (null) {
@@ -1611,7 +1547,7 @@ actor class PostBucket() = this {
     modifiedHashMap.put(postId, now);
 
     categoryHashMap.delete(postId);
-    let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+    let postCoreActor = CanisterDeclarations.getPostCoreCanister();
     //removes the post category from the PostCore canister
     await postCoreActor.addPostCategory(postId, "", now);
     #ok(buildPost(postId));
@@ -1649,7 +1585,7 @@ actor class PostBucket() = this {
     modifiedHashMap.put(postId, now);
 
     categoryHashMap.put(postId, category);
-    let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+    let postCoreActor = CanisterDeclarations.getPostCoreCanister();
     //add the post category in the PostCore canister
     await postCoreActor.addPostCategory(postId, category, now);
 
@@ -1689,7 +1625,7 @@ actor class PostBucket() = this {
     let now = U.epochTime();
     modifiedHashMap.put(postId, now);
     isDraftHashMap.put(postId, isDraft);
-    let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+    let postCoreActor = CanisterDeclarations.getPostCoreCanister();
     let writerHandle = updatingPost.creator;
     let writerPrincipalId = U.safeGet(handleReverseHashMap, writerHandle, "");
     let keyProperties = await postCoreActor.updatePostDraft(postId, isDraft, now, writerPrincipalId);
@@ -1774,7 +1710,7 @@ actor class PostBucket() = this {
         resultsHashmap.put(postId, #err(Unauthorized));
         isValid := false;
       };
-      let postCoreActor = actor (postCoreCanisterId) : PostCoreInterface;
+      let postCoreActor = CanisterDeclarations.getPostCoreCanister();
 
       let principalId = Principal.toText(caller);
       var savedCreatedDate : Int = 0;
@@ -1894,7 +1830,7 @@ actor class PostBucket() = this {
       let content = U.safeGet(contentHashMap, postId, "");
       let current = handle # " " # title # " " # subtitle;
       let tags = U.safeGet(tagNamesHashMap, postId, []);
-      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
       ignore PostIndexCanister.indexPost(postId, "", current, [], tags);
 
     };
@@ -2122,7 +2058,7 @@ actor class PostBucket() = this {
       return #err("Not authorized");
     };
 
-    let FrontEndCanister = actor (frontendCanisterId) : FrontendInterface;
+    let FrontEndCanister = CanisterDeclarations.getFrontendCanister();
 
     var count = principalIdHashMap.size();
     // var postId = "2";
@@ -2153,7 +2089,7 @@ actor class PostBucket() = this {
       return #err("Not authorized");
     };
 
-    let FrontEndCanister = actor (frontendCanisterId) : Types.FrontendInterface;
+    let FrontEndCanister = CanisterDeclarations.getFrontendCanister();
 
     var post : PostBucketType = buildPost(postId);
     var content = await generateContent(postId);
@@ -2200,11 +2136,11 @@ actor class PostBucket() = this {
 
     //func buildPostUrl(postId : Text, handle : Text, title : Text)
 
-    let property = if (frontendCanisterId == "exwqn-uaaaa-aaaaf-qaeaa-cai") {
+    let property = if (ENV.NUANCE_ASSETS_CANISTER_ID == "exwqn-uaaaa-aaaaf-qaeaa-cai") {
       "https://nuance.xyz"
 
     } else {
-      "https://" # frontendCanisterId # ".ic0.app";
+      "https://" # ENV.NUANCE_ASSETS_CANISTER_ID # ".ic0.app";
     };
 
     var content = " <!DOCTYPE html> <html lang=\"en\"> <head> <meta charset=\"UTF-8\"> <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"> <title>"
@@ -2352,7 +2288,7 @@ actor class PostBucket() = this {
 
         //check if caller has a nuance account
         let userPrincipalId = Principal.toText(caller);
-        let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+        let UserCanister = CanisterDeclarations.getUserCanister();
         var user : ?User = await UserCanister.getUserInternal(userPrincipalId);
         switch (user) {
           case (?val) {
@@ -2610,7 +2546,7 @@ actor class PostBucket() = this {
       case (?postId) {
         //check if caller has a nuance account
         let userPrincipalId = Principal.toText(caller);
-        let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+        let UserCanister = CanisterDeclarations.getUserCanister();
         var user : ?User = await UserCanister.getUserInternal(userPrincipalId);
         switch (user) {
           case (?val) {
@@ -2642,7 +2578,7 @@ actor class PostBucket() = this {
       case (?postId) {
         //check if caller has a nuance account
         let userPrincipalId = Principal.toText(caller);
-        let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+        let UserCanister = CanisterDeclarations.getUserCanister();
         var user : ?User = await UserCanister.getUserInternal(userPrincipalId);
         switch (user) {
           case (?val) {
@@ -2674,7 +2610,7 @@ actor class PostBucket() = this {
       case (?postId) {
         //check if caller has a nuance account
         let userPrincipalId = Principal.toText(caller);
-        let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+        let UserCanister = CanisterDeclarations.getUserCanister();
         var user : ?User = await UserCanister.getUserInternal(userPrincipalId);
         switch (user) {
           case (?val) {

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -430,7 +430,7 @@ actor PostCore {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -447,7 +447,7 @@ actor PostCore {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -666,7 +666,7 @@ actor PostCore {
   };
 
   public shared ({ caller }) func deletePostFromUserDebug(handle : Text, postId : Text) : async Result.Result<[Text], Text> {
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -32,6 +32,7 @@ import Prim "mo:prim";
 import CanisterDeclarations "../shared/CanisterDeclarations";
 import Versions "../shared/versions";
 import OperationLog "../shared/Types";
+import ENV "../shared/env";
 
 actor PostCore {
 
@@ -84,11 +85,6 @@ actor PostCore {
   stable var totalViewsToday : Nat = 0; //stored by date and reset by timer daily, incremented by viewPost func
   stable var totalDailyViewsDate : Text = "20230101";
   stable var isStoreSEOcalled = false;
-  stable var frontendCanisterId = "";
-  //other canister ids that this canister interacts with
-  stable var userCanisterId = "";
-  stable var postIndexCanisterId = "";
-  stable var cyclesDispenserCanisterId = "";
 
   stable var _canistergeekMonitorUD : ?Canistergeek.UpgradeData = null;
   stable var bucketCanisterIdsEntries : [(Text, Text)] = [];
@@ -183,12 +179,8 @@ actor PostCore {
     };
 
     //check the caller is admin or the canister's itself
-    if (not isAdmin(caller) and not Principal.equal(caller, Principal.fromActor(PostCore))) {
+    if (not isAdmin(caller) and not Principal.equal(caller, Principal.fromActor(PostCore)) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
-    };
-
-    if (frontendCanisterId == "") {
-      return #err("Frontend canister hasn't been initialized yet.");
     };
 
     if (activeBucketCanisterId != "") {
@@ -206,26 +198,35 @@ actor PostCore {
       Cycles.add(5_000_000_000_000);
       let bucketCanister = await PostBucket.PostBucket();
       let canisterId = Principal.toText(Principal.fromActor(bucketCanister));
-      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
-      switch (await PostIndexCanister.registerAdmin(canisterId)) {
+      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
+      switch (await PostIndexCanister.registerCanister(canisterId)) {
         case (#err(err)) {
           return #err("An error occured while registering the bucket canister as admin in PostIndex canister.");
         };
         case (_) {};
       };
 
-      let CyclesDispenserCanister = CanisterDeclarations.getCyclesDispenserCanister(cyclesDispenserCanisterId);
+      let CyclesDispenserCanister = CanisterDeclarations.getCyclesDispenserCanister();
       switch (await CyclesDispenserCanister.addCanister({ canisterId = canisterId; minimumThreshold = 10_000_000_000_000; topUpAmount = 5_000_000_000_000 })) {
         case (#err(err)) {
           return #err("An error occured while adding the bucket canister in CyclesDispenser.");
         };
         case (_) {};
       };
+
+      let MetricsCanister = CanisterDeclarations.getMetricsCanister();
+      switch (await MetricsCanister.registerCanister(canisterId)) {
+        case (#err(err)) {
+          return #err("An error occured while adding the bucket canister to Metrics canister.");
+        };
+        case (_) {};
+      };
+
       Debug.print("Newly created bucket canister canister id is " # canisterId);
 
       try {
         //authorize bucket canister in frontend canister
-        let frontendActor = actor (frontendCanisterId) : FrontendInterface;
+        let frontendActor = CanisterDeclarations.getFrontendCanister();
         Debug.print("frontend actor defined successfully");
         await frontendActor.authorize(Principal.fromActor(bucketCanister));
         Debug.print("frontend actor authorize went succesful");
@@ -233,7 +234,7 @@ actor PostCore {
         Debug.print("authorize error");
       };
 
-      switch (await bucketCanister.initializeBucketCanister(List.toArray(admins), List.toArray(nuanceCanisters), List.toArray(cgusers), Iter.toArray(nftCanisterIdsHashmap.entries()), Principal.toText(Principal.fromActor(PostCore)), frontendCanisterId, postIndexCanisterId, userCanisterId)) {
+      switch (await bucketCanister.initializeBucketCanister(List.toArray(admins), List.toArray(nuanceCanisters), List.toArray(cgusers), Iter.toArray(nftCanisterIdsHashmap.entries()), Principal.toText(Principal.fromActor(PostCore)), ENV.NUANCE_ASSETS_CANISTER_ID, ENV.POST_INDEX_CANISTER_ID, ENV.USER_CANISTER_ID)) {
         case (#ok(cai)) {
           activeBucketCanisterId := canisterId;
           bucketCanisterIdsHashMap.put(canisterId, Nat.toText(postId + 1));
@@ -264,48 +265,15 @@ actor PostCore {
 
   //initialize method to store the canister ids that this canister interacts with
   public shared ({ caller }) func initializeCanister(postIndexCai : Text, userCai : Text, cyclesDispenserCai : Text) : async Result.Result<Text, Text> {
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    for (bucketCanisterId in bucketCanisterIdsHashMap.keys()) {
-      let bucketActor = actor (bucketCanisterId) : BucketCanisterInterface;
-
-      switch (await bucketActor.initializeCanister(postIndexCai, userCai)) {
-        case (#ok(list)) {};
-        case (_) {
-          return #err("Error while initializing the bucket canister " # bucketCanisterId);
-        };
-      };
-    };
-    postIndexCanisterId := postIndexCai;
-    userCanisterId := userCai;
-    cyclesDispenserCanisterId := cyclesDispenserCai;
-    #ok(postIndexCanisterId # ", " # userCanisterId # ", " # cyclesDispenserCanisterId);
+    return #err("Deprecated function.");
   };
 
   public shared ({ caller }) func setFrontendCanisterId(canisterId : Text) : async Result.Result<Text, Text> {
-
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-
-    frontendCanisterId := canisterId;
-    #ok(frontendCanisterId);
+    return #err("Deprecated function.");
   };
 
   public shared query ({ caller }) func getFrontendCanisterId() : async Result.Result<Text, Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    #ok(frontendCanisterId);
+    #ok(ENV.NUANCE_ASSETS_CANISTER_ID);
   };
 
   public shared ({ caller }) func testInstructionSize() : async Text {
@@ -340,8 +308,41 @@ actor PostCore {
 
   private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
+    U.arrayContains(ENV.POSTCORE_CANISTER_ADMINS, c);
+  };
+
+  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
+    if (isAnonymous(caller)) {
+      return #err("Cannot use this method anonymously.");
+    };
+
+    #ok(ENV.POSTCORE_CANISTER_ADMINS);
+  };
+
+  private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
+
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
+
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
   };
 
   private func isAuthor(caller : Principal, postId : Text) : Bool {
@@ -353,48 +354,7 @@ actor PostCore {
     var exists = List.find<Text>(nuanceCanisters, func(val : Text) : Bool { val == c });
     exists != null;
   };
-
-  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    #ok(List.toArray(admins));
-  };
-
-  //platform operators, similar to admins but restricted to a few functions
-
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
-  };
-
-  private func isPlatformOperator(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
+  
 
   public shared query ({ caller }) func getTrustedCanisters() : async Result.Result<[Text], Text> {
     /*if (not isAdmin(caller)) {
@@ -421,7 +381,7 @@ actor PostCore {
       return #err("Cannot use this method anonymously.");
     };
 
-    if (not isAdmin(caller) and not Principal.equal(Principal.fromActor(PostCore), caller)) {
+    if (not isAdmin(caller) and not Principal.equal(Principal.fromActor(PostCore), caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -497,43 +457,6 @@ actor PostCore {
     return Principal.fromActor(PostCore);
   };
 
-  //This function should be invoked immediately after the canister is deployed via script.
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    if (not isThereEnoughMemoryPrivate()) {
-      return #err("Canister reached the maximum memory threshold. Please try again later.");
-    };
-
-    //validate input
-    let principalFromText = Principal.fromText(id);
-
-    canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Cannot use this method anonymously.");
-    };
-
-    canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
-    #ok();
-  };
 
   //#region Post Management
   //getNextPostId method can be called by bucket canisters only
@@ -614,7 +537,7 @@ actor PostCore {
       return #err("Author Text length exceeded");
     };
 
-    if (not Principal.equal(caller, Principal.fromText(userCanisterId))) {
+    if (not Principal.equal(caller, Principal.fromText(ENV.USER_CANISTER_ID))) {
       return #err(Unauthorized);
     };
 
@@ -882,7 +805,7 @@ actor PostCore {
     };
 
     let callerPrincipalId = Principal.toText(caller);
-    let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+    let UserCanister = CanisterDeclarations.getUserCanister();
     var user = await UserCanister.getUserInternal(callerPrincipalId);
     switch (user) {
       case (null) {};
@@ -994,7 +917,7 @@ actor PostCore {
     // retrieve user handle if it's not already mapped to the principalId
     var userHandle = U.safeGet(handleHashMap, principalId, "");
     if (userHandle == "") {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       var user = await UserCanister.getUserInternal(principalId);
       switch (user) {
         case (null) return #err("cross canister User not found");
@@ -1011,7 +934,7 @@ actor PostCore {
     //check if the given creator is valid - only for publication posts
     let creatorHandle = U.safeGet(handleHashMap, postModel.creator, "");
     if (creatorHandle == "" and isPublication) {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       var user = await UserCanister.getUserInternal(postModel.creator);
       switch (user) {
         case (null) {
@@ -1109,7 +1032,7 @@ actor PostCore {
         let current = handle # " " # postModel.title # " " # postModel.subtitle;
         let prevTags = getTagNamesByPostId(postBucketReturn.postId);
         let currentTags = getTagNamesByTagIds(postModel.tagIds);
-        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
         var indexResult = await PostIndexCanister.indexPost(postBucketReturn.postId, previous, current, prevTags, currentTags);
 
         switch (indexResult) {
@@ -1662,7 +1585,7 @@ actor PostCore {
 
     //if the publication canister id is not stored in the bucket canister, fetch it from user canister and store it first.
     if (publicationPrincipalId == "") {
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       let userReturn = await UserCanister.getPrincipalByHandle(U.lowerCase(publicationHandle));
       switch (userReturn) {
         case (#ok(principal)) {
@@ -1879,7 +1802,7 @@ actor PostCore {
     //this if statement is executed only for the first chunk
     if (indexStart == 0) {
       //clear the PostIndex canister at start
-      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+      let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
       ignore PostIndexCanister.clearIndex();
       //migrate the views history
       let viewsHistory = await oldPostCanister.getViewsHistoryHashmap();
@@ -2093,7 +2016,7 @@ actor PostCore {
             };
           };
         };
-        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
         ignore await PostIndexCanister.indexPosts(Buffer.toArray(indexingArguments));
 
         return #ok(Buffer.toArray(resultsBuffer));
@@ -2122,7 +2045,7 @@ actor PostCore {
       return #err("Canister reached the maximum memory threshold. Please try again later.");
     };
 
-    let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+    let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
     var result = await PostIndexCanister.clearIndex();
 
     switch (result) {
@@ -2187,7 +2110,7 @@ actor PostCore {
     if (Principal.toText(caller) != principalId) {
 
       // check if user has enough tokens to clap
-      let UserCanister = CanisterDeclarations.getUserCanister(userCanisterId);
+      let UserCanister = CanisterDeclarations.getUserCanister();
       var tokenAmounts = await UserCanister.getNuaBalance(Principal.toText(caller));
       switch (tokenAmounts) {
         case (#ok(balance)) Debug.print("balance: " # balance);
@@ -2750,7 +2673,7 @@ actor PostCore {
         let prevContent = post.content;
         let previous = handle # " " # prevTitle # " " # prevSubtitle;
         let prevTags = getTagNamesByPostId(postId);
-        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister(postIndexCanisterId);
+        let PostIndexCanister = CanisterDeclarations.getPostIndexCanister();
         var indexResult = await PostIndexCanister.indexPost(postId, previous, "", prevTags, [""]);
       };
       case (_) {};
@@ -3005,7 +2928,7 @@ actor PostCore {
 
     canistergeekMonitor.collectMetrics();
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -3842,13 +3765,15 @@ actor PostCore {
     if (not isAdmin(caller) and not isNuanceCanister(caller)) {
       return #err(Unauthorized);
     };
-    let CyclesDispenserCanister = CanisterDeclarations.getCyclesDispenserCanister(cyclesDispenserCanisterId);
+    let CyclesDispenserCanister = CanisterDeclarations.getCyclesDispenserCanister();
     ignore await CyclesDispenserCanister.addCanister({
       canisterId = canisterId;
       minimumThreshold = minimumThreshold;
       topUpAmount = topUpAmount;
     });
 
+    //add the canister to Metrics canister
+    ignore await CanisterDeclarations.getMetricsCanister().registerCanister(canisterId);
     return #ok();
   };
 
@@ -3872,7 +3797,7 @@ actor PostCore {
     };
 
     Debug.print("PostCore -> Active bucket canister id: " # activeBucketCanisterId);
-    if (activeBucketCanisterId == "" and frontendCanisterId != "") {
+    if (activeBucketCanisterId == "") {
       try {
         switch (await createNewBucketCanister()) {
           case (#ok(result)) {

--- a/src/PostIndex/main.mo
+++ b/src/PostIndex/main.mo
@@ -138,7 +138,7 @@ actor PostIndex {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -155,7 +155,7 @@ actor PostIndex {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/PostIndex/main.mo
+++ b/src/PostIndex/main.mo
@@ -18,6 +18,7 @@ import Types "./types";
 import Cycles "mo:base/ExperimentalCycles";
 import Prim "mo:prim";
 import Versions "../shared/versions";
+import ENV "../shared/env";
 
 actor PostIndex {
   let Unauthorized = "Unauthorized";
@@ -55,6 +56,7 @@ actor PostIndex {
   //#region Security Management
 
   stable var admins : List.List<Text> = List.nil<Text>();
+  stable var trustedCanisters : List.List<Text> = List.nil<Text>();
   stable var platformOperators : List.List<Text> = List.nil<Text>();
   stable var cgusers : List.List<Text> = List.nil<Text>();
 
@@ -64,8 +66,7 @@ actor PostIndex {
 
   private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
+    U.arrayContains(ENV.POSTINDEX_CANISTER_ADMINS, c);
   };
 
   public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
@@ -73,42 +74,41 @@ actor PostIndex {
       return #err("Cannot use this method anonymously.");
     };
 
-    #ok(List.toArray(admins));
-  };
-
-  //platform operators, similar to admins but restricted to a few functions
-
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
+    #ok(ENV.POSTINDEX_CANISTER_ADMINS);
   };
 
   private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
+
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
+
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  private func isTrustedCanister(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
+    var exists = List.find<Text>(trustedCanisters, func(val : Text) : Bool { val == c });
     exists != null;
   };
+
 
   public shared query ({ caller }) func getCgUsers() : async Result.Result<[Text], Text> {
     if (isAnonymous(caller)) {
@@ -162,9 +162,8 @@ actor PostIndex {
     #ok();
   };
 
-  //This function should be invoked immediately after the canister is deployed via script.
-  //The Post canister id should be added as an admin.
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+  //Registers a trusted canister
+  public shared ({ caller }) func registerCanister(id : Text) : async Result.Result<(), Text> {
     if (isAnonymous(caller)) {
       return #err("Cannot use this method anonymously.");
     };
@@ -174,28 +173,32 @@ actor PostIndex {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
+    if (not isPlatformOperator(caller) and not isAdmin(caller)) {
       return #err(Unauthorized);
     };
 
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
+    if (not List.some<Text>(trustedCanisters, func(val : Text) : Bool { val == id })) {
+      trustedCanisters := List.push<Text>(id, trustedCanisters);
     };
 
     #ok();
   };
 
-  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+  public shared ({ caller }) func unregisterCanister(id : Text) : async Result.Result<(), Text> {
     if (isAnonymous(caller)) {
       return #err("Cannot use this method anonymously.");
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
+    trustedCanisters := List.filter<Text>(trustedCanisters, func(val : Text) : Bool { val != id });
     #ok();
+  };
+
+  public shared query ({ caller }) func getTrustedCanisters() : async Result.Result<[Text], Text> {
+    #ok(List.toArray(trustedCanisters));
   };
 
   //#endregion
@@ -234,7 +237,7 @@ actor PostIndex {
     canistergeekMonitor.collectMetrics();
     Debug.print("PostIndex->IndexPosts");
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isTrustedCanister(caller)) {
       return [#err("PostIndex->IndexPost Unauthorized")];
     };
 
@@ -310,7 +313,7 @@ actor PostIndex {
     canistergeekMonitor.collectMetrics();
     Debug.print("PostIndex->IndexPost PostId: " # postId);
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isTrustedCanister(caller)) {
       return #err("PostIndex->IndexPost Unauthorized");
     };
 
@@ -599,7 +602,7 @@ actor PostIndex {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isTrustedCanister(caller)) {
       return #err(Unauthorized);
     };
 

--- a/src/Storage/main.mo
+++ b/src/Storage/main.mo
@@ -16,7 +16,10 @@ import StorageSolution "./storage/storage";
 import Cycles "mo:base/ExperimentalCycles";
 import IC "./ic.types";
 import Blob "mo:base/Blob";
-import Array "mo:base/Array";import Versions "../shared/versions";
+import Array "mo:base/Array";
+import Versions "../shared/versions";
+import ENV "../shared/env";
+import U "../shared/utils";
 
 
 // actor Storage {
@@ -71,53 +74,45 @@ public shared ({ caller }) func validate(input : Any) : async Validate {
         Principal.equal(caller, Principal.fromText("2vxsx-fae"));
     };
 
-    func isAdmin(caller : Principal) : Bool {
+    private func isAdmin(caller : Principal) : Bool {
         var c = Principal.toText(caller);
-        var exists = List.find<Text>(admins, func(val: Text) : Bool { val == c });
-        exists != null;
+        U.arrayContains(ENV.STORAGE_CANISTER_ADMINS, c);
     };
 
-    public shared ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-         if (isAnonymous(caller)) {
-            return #err("Anonymous cannot call this method");
+    public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
+        if (isAnonymous(caller)) {
+        return #err("Cannot use this method anonymously.");
         };
 
-        #ok(List.toArray(admins));
-    };
-
-    //platform operators, similar to admins but restricted to a few functions
-
-    public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-        let principal = Principal.toText(caller);
-        
-        if (not isAdmin(caller)) {
-            return #err("Unauthorized");
-        };
-
-        if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-            platformOperators := List.push<Text>(id, platformOperators);
-        };
-
-        #ok();
-    };
-
-    public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-        if (not isAdmin(caller)) {
-            return #err("Unauthorized");
-        };
-        platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-        #ok();
-    };
-
-    public shared query func getPlatformOperators() : async List.List<Text> {
-        platformOperators;
+        #ok(ENV.STORAGE_CANISTER_ADMINS);
     };
 
     private func isPlatformOperator(caller : Principal) : Bool {
-        var c = Principal.toText(caller);
-        var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
-        exists != null;
+        ENV.isPlatformOperator(caller)
     };
+
+    public shared query func getPlatformOperators() : async List.List<Text> {
+        List.fromArray(ENV.PLATFORM_OPERATORS);
+    };
+
+    //These methods are deprecated. Admins are handled by env.mo file
+    public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+        #err("Deprecated function")
+    };
+
+    public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+        #err("Deprecated function")
+    };
+
+    //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+    public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+        #err("Deprecated function.")
+    };
+
+    public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+        #err("Deprecated function.")
+    };
+
 
     public shared query ({ caller }) func getCgUsers() : async Result.Result<[Text], Text> {
          if (isAnonymous(caller)) {
@@ -168,36 +163,7 @@ public shared ({ caller }) func validate(input : Any) : async Validate {
     };
 
 
-    //This function should be invoked immediately after the canister is deployed via script.
-    public shared({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
-         if (isAnonymous(caller)) {
-            return #err("Anonymous cannot call this method");
-        };
 
-        canistergeekMonitor.collectMetrics();
-        if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-            return #err(Unauthorized);
-        };
-
-        if (not List.some<Text>(admins, func(val: Text) : Bool { val == id })) {
-            admins := List.push<Text>(id, admins);
-            await storageSolution.registerAdmin(id);
-        };
-        #ok();
-    };
-
-    public shared({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-         if (isAnonymous(caller)) {
-            return #err("Anonymous cannot call this method");
-        };
-
-        canistergeekMonitor.collectMetrics();
-        if (not isAdmin(caller)) {
-            return #err(Unauthorized);
-        };
-        admins := List.filter<Text>(admins, func(val: Text) : Bool { val != id });
-        #ok();
-    };
     // admin function to retire any data canister for writing. It will still be used for  reading
     public shared({caller}) func retiredDataCanisterIdForWriting(canisterId: Text) : async Result.Result<(), Text> {
          if (isAnonymous(caller)) {

--- a/src/Storage/main.mo
+++ b/src/Storage/main.mo
@@ -138,7 +138,7 @@ public shared ({ caller }) func validate(input : Any) : async Validate {
         };
 
         canistergeekMonitor.collectMetrics();
-        if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+        if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
             return #err(Unauthorized);
         };
 
@@ -155,7 +155,7 @@ public shared ({ caller }) func validate(input : Any) : async Validate {
         };
 
         canistergeekMonitor.collectMetrics();
-        if (not isAdmin(caller)) {
+        if (not isAdmin(caller) and not isPlatformOperator(caller)) {
             return #err(Unauthorized);
         };
         cgusers := List.filter<Text>(cgusers, func(val: Text) : Bool { val != id });

--- a/src/User/main.mo
+++ b/src/User/main.mo
@@ -22,6 +22,7 @@ import Cycles "mo:base/ExperimentalCycles";
 import Time "mo:base/Time";
 import Prim "mo:prim";
 import Versions "../shared/versions";
+import ENV "../shared/env";
 
 actor User {
   let Unauthorized = "Unauthorized";
@@ -132,57 +133,48 @@ actor User {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
   };
 
-  func isAdmin(caller : Principal) : Bool {
+  private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
-    var exists = List.find<Text>(admins, func(val : Text) : Bool { val == c });
-    exists != null;
+    U.arrayContains(ENV.USER_CANISTER_ADMINS, c);
+  };
+
+  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
+    if (isAnonymous(caller)) {
+      return #err("Cannot use this method anonymously.");
+    };
+
+    #ok(ENV.USER_CANISTER_ADMINS);
+  };
+
+  private func isPlatformOperator(caller : Principal) : Bool {
+    ENV.isPlatformOperator(caller)
+  };
+
+  public shared query func getPlatformOperators() : async List.List<Text> {
+    List.fromArray(ENV.PLATFORM_OPERATORS);
+  };
+
+  //These methods are deprecated. Admins are handled by env.mo file
+  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function")
+  };
+
+  //platform operators, similar to admins but restricted to a few functions -> deprecated. Use env.mo file
+  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
+  };
+
+  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
+    #err("Deprecated function.")
   };
 
   func isNuanceCanister(caller : Principal) : Bool {
     var c = Principal.toText(caller);
     var exists = List.find<Text>(nuanceCanisters, func(val : Text) : Bool { val == c });
-    exists != null;
-  };
-
-  public shared query ({ caller }) func getAdmins() : async Result.Result<[Text], Text> {
-    if (isAnonymous(caller)) {
-      return #err("Anonymous cannot call this method");
-    };
-
-    #ok(List.toArray(admins));
-  };
-
-  //platform operators, similar to admins but restricted to a few functions
-
-  public shared ({ caller }) func registerPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    let principal = Principal.toText(caller);
-
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-
-    if (not List.some<Text>(platformOperators, func(val : Text) : Bool { val == id })) {
-      platformOperators := List.push<Text>(id, platformOperators);
-    };
-
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterPlatformOperator(id : Text) : async Result.Result<(), Text> {
-    if (not isAdmin(caller)) {
-      return #err("Unauthorized");
-    };
-    platformOperators := List.filter<Text>(platformOperators, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared query func getPlatformOperators() : async List.List<Text> {
-    platformOperators;
-  };
-
-  private func isPlatformOperator(caller : Principal) : Bool {
-    var c = Principal.toText(caller);
-    var exists = List.find<Text>(platformOperators, func(val : Text) : Bool { val == c });
     exists != null;
   };
 
@@ -246,27 +238,6 @@ actor User {
     #ok();
   };
 
-  //This function should be invoked immediately after the canister is deployed via script.
-  public shared ({ caller }) func registerAdmin(id : Text) : async Result.Result<(), Text> {
-    if (isAnonymous(caller)) {
-      return #err("Anonymous cannot call this method");
-    };
-
-    if (not isThereEnoughMemoryPrivate()) {
-      return #err("Canister reached the maximum memory threshold. Please try again later.");
-    };
-
-    canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(admins) > 0 and not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-
-    if (not List.some<Text>(admins, func(val : Text) : Bool { val == id })) {
-      admins := List.push<Text>(id, admins);
-    };
-
-    #ok();
-  };
 
   public shared ({ caller }) func registerCanister(id : Text) : async Result.Result<(), Text> {
 
@@ -298,20 +269,6 @@ actor User {
       return #err(Unauthorized);
     };
     nuanceCanisters := List.filter<Text>(nuanceCanisters, func(val : Text) : Bool { val != id });
-    #ok();
-  };
-
-  public shared ({ caller }) func unregisterAdmin(id : Text) : async Result.Result<(), Text> {
-
-    if (isAnonymous(caller)) {
-      return #err("Anonymous cannot call this method");
-    };
-
-    canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
-      return #err(Unauthorized);
-    };
-    admins := List.filter<Text>(admins, func(val : Text) : Bool { val != id });
     #ok();
   };
 
@@ -1608,7 +1565,7 @@ actor User {
       return;
     };
 
-    if (isAdmin(caller)) {
+    if (isAdmin(caller) or isPlatformOperator(caller)) {
       for (handleEntry in handleHashMap.entries()) {
         accountIdsToHandleHashMap.put(U.principalToAID(handleEntry.0), handleEntry.1);
       };
@@ -1643,7 +1600,7 @@ actor User {
 
   public shared query ({ caller }) func getCanisterMetrics(parameters : Canistergeek.GetMetricsParameters) : async ?Canistergeek.CanisterMetrics {
 
-    if (not isCgUser(caller) and not isAdmin(caller)) {
+    if (not isCgUser(caller) and not isAdmin(caller) and not isPlatformOperator(caller)) {
       Prelude.unreachable();
     };
     Debug.print("User->getCanisterMetrics: The method getCanistermetrics was called from the UI successfully");
@@ -1651,7 +1608,7 @@ actor User {
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not isCgUser(caller) and not isAdmin(caller)) {
+    if (not isCgUser(caller) and not isAdmin(caller) and not isPlatformOperator(caller)) {
       Prelude.unreachable();
     };
     canistergeekMonitor.collectMetrics();
@@ -1790,7 +1747,7 @@ actor User {
       return ("Anonymous cannot call this method");
     };
 
-    if (isAdmin(caller) != true) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return "You are not authorized to run this method";
     };
 

--- a/src/User/main.mo
+++ b/src/User/main.mo
@@ -214,7 +214,7 @@ actor User {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller)) {
+    if (List.size<Text>(cgusers) > 0 and not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
 
@@ -231,7 +231,7 @@ actor User {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     cgusers := List.filter<Text>(cgusers, func(val : Text) : Bool { val != id });

--- a/src/shared/CanisterDeclarations.mo
+++ b/src/shared/CanisterDeclarations.mo
@@ -1,5 +1,6 @@
 import Result "mo:base/Result";
 import List "mo:base/List";
+import ENV "env";
 module{
 
 
@@ -60,8 +61,8 @@ module{
         updateHandle : (existingHandle : Text, newHandle : Text, postCanisterId : Text, publicationWritersEditorsPrincipals : ?[Text]) -> async Result.Result<User, Text>;
     };
 
-    public func getUserCanister(canisterId: Text) : UserCanisterInterface {
-        let canister : UserCanisterInterface = actor(canisterId);
+    public func getUserCanister() : UserCanisterInterface {
+        let canister : UserCanisterInterface = actor(ENV.USER_CANISTER_ID);
         return canister;
     };
 
@@ -145,10 +146,14 @@ module{
         getPostKeyProperties : (postId : Text) -> async Result.Result<PostKeyProperties, Text>;
         registerNftCanisterId : (canisterId : Text, handle : Text) -> async Result.Result<Text, Text>;
         addCanisterToCyclesDispenser : (canisterId : Text, minimumThreshold : Nat, topUpAmount : Nat) -> async Result.Result<(), Text>;
+        updatePostDraft : (postId : Text, isDraft : Bool, time : Int, writerPrincipalId : Text) -> async PostKeyProperties;
+        makePostPublication : (postId : Text, publicationHandle : Text, userHandle : Text, isDraft : Bool) -> async ();
+        getNextPostId : () -> async Result.Result<Text, Text>;
+        addPostCategory : (postId : Text, category : Text, time : Int) -> async ()
     };
 
-    public func getPostCoreCanister(canisterId: Text) : PostCoreCanisterInterface {
-        let canister : PostCoreCanisterInterface = actor(canisterId);
+    public func getPostCoreCanister() : PostCoreCanisterInterface {
+        let canister : PostCoreCanisterInterface = actor(ENV.POST_CORE_CANISTER_ID);
         return canister;
     };
 
@@ -167,11 +172,12 @@ module{
         indexPost : (postId : Text, oldHtml : Text, newHtml : Text, oldTags: [Text], newTags: [Text]) -> async IndexPostResult;
         indexPosts : (indexPostModels: [IndexPostModel]) -> async [IndexPostResult];
         clearIndex : () -> async ClearIndexResult;
-        registerAdmin : (id : Text) -> async Result.Result<(), Text>
+        registerAdmin : (id : Text) -> async Result.Result<(), Text>;
+        registerCanister : (id : Text) -> async Result.Result<(), Text>
     };
 
-    public func getPostIndexCanister(canisterId: Text) : PostIndexCanisterInterface {
-        let canister : PostIndexCanisterInterface = actor(canisterId);
+    public func getPostIndexCanister() : PostIndexCanisterInterface {
+        let canister : PostIndexCanisterInterface = actor(ENV.POST_INDEX_CANISTER_ID);
         return canister;
     };
 
@@ -180,8 +186,8 @@ module{
     //****************KINICENDPOINT CANISTER*****************
     public type KinicEndpointCanisterInterface = actor{};
 
-    public func getKinicEndpointCanister(canisterId: Text) : KinicEndpointCanisterInterface {
-        let canister : KinicEndpointCanisterInterface = actor(canisterId);
+    public func getKinicEndpointCanister() : KinicEndpointCanisterInterface {
+        let canister : KinicEndpointCanisterInterface = actor(ENV.KINIC_ENDPOINT_CANISTER_ID);
         return canister;
     };
 
@@ -189,8 +195,8 @@ module{
     //****************FASTBLOCKSEMAILOPTIN CANISTER*****************
     public type FastBlocksEmailOptInCanisterInterface = actor{};
 
-    public func getFastblocksEmailOptInCanister(canisterId: Text) : FastBlocksEmailOptInCanisterInterface {
-        let canister : FastBlocksEmailOptInCanisterInterface = actor(canisterId);
+    public func getFastblocksEmailOptInCanister() : FastBlocksEmailOptInCanisterInterface {
+        let canister : FastBlocksEmailOptInCanisterInterface = actor(ENV.FASTBLOCKS_EMAIL_OPT_IN_CANISTER_ID);
         return canister;
     };
 
@@ -221,8 +227,8 @@ module{
         addCanister : (canister: AddCanisterModel) -> async Result.Result<RegisteredCanister, Text>
     };
 
-    public func getCyclesDispenserCanister(canisterId: Text) : CyclesDispenserCanisterInterface {
-        let canister : CyclesDispenserCanisterInterface = actor(canisterId);
+    public func getCyclesDispenserCanister() : CyclesDispenserCanisterInterface {
+        let canister : CyclesDispenserCanisterInterface = actor(ENV.CYCLES_DISPENSER_CANISTER_ID);
         return canister;
     };
 
@@ -233,8 +239,8 @@ module{
         createNftCanister : () -> async Result.Result<Text, Text>
     };
 
-    public func getNftFactoryCanister(canisterId: Text) : NftFactoryCanisterInterface {
-        let canister : NftFactoryCanisterInterface = actor(canisterId);
+    public func getNftFactoryCanister() : NftFactoryCanisterInterface {
+        let canister : NftFactoryCanisterInterface = actor(ENV.NFT_FACTORY_CANISTER_ID);
         return canister;
     };
 
@@ -308,4 +314,59 @@ module{
     };
 
 
+
+    //##########################FRONTEND_CANISTER############################
+
+    public  type BatchId = Nat;
+    public type ChunkId = Nat;
+    public type Key = Text;
+    public type Time = Int;
+
+    // Add or change content for an asset, by content encoding
+    public type SetAssetContentArguments =  {
+        key: Key;
+        content_encoding: Text;
+        chunk_ids:  [ChunkId];
+        sha256: ?Blob;
+    };
+
+    // Remove content for an asset, by content encoding
+    public type UnsetAssetContentArguments =  {
+        key: Key;
+        content_encoding: Text;
+    };
+
+    // Delete an asset
+    public type DeleteAssetArguments =  {
+        key: Key;
+    };
+
+    // Reset everything
+    public type ClearArguments =  {};
+    public type FrontendInterface = actor {
+        store: ({
+            key: Key;
+            content_type: Text;
+            content_encoding: Text;
+            content: Blob;
+            sha256: ?Blob}) -> ();
+        delete_asset: ({key: Key;}) -> ();  
+        authorize: (principal: Principal) -> async ();
+        take_ownership: () -> async ();
+    };
+
+    public func getFrontendCanister() : FrontendInterface {
+        let canister : FrontendInterface = actor(ENV.NUANCE_ASSETS_CANISTER_ID);
+        return canister;
+    };
+
+    //###########################__METRICS_CANISTER__
+    public type MetricsCanisterInterface = actor{
+        registerCanister : (id : Text) -> async Result.Result<(), Text>
+    };
+
+    public func getMetricsCanister() : MetricsCanisterInterface {
+        let canister : MetricsCanisterInterface = actor(ENV.METRICS_CANISTER_ID);
+        return canister;
+    };
 }

--- a/src/shared/env.mo
+++ b/src/shared/env.mo
@@ -1,3 +1,4 @@
+import Principal "mo:base/Principal";
 module {
   public let USER_CANISTER_ID = "rtqeo-eyaaa-aaaaf-qaana-cai";
   public let POST_CORE_CANISTER_ID = "322sd-3iaaa-aaaaf-qakgq-cai";
@@ -8,5 +9,86 @@ module {
   public let CYCLES_DISPENSER_CANISTER_ID = "353ux-wqaaa-aaaaf-qakga-cai";
   public let NUANCE_ASSETS_CANISTER_ID = "exwqn-uaaaa-aaaaf-qaeaa-cai";
   public let METRICS_CANISTER_ID = "xjlvo-hyaaa-aaaam-qbcga-cai";
+  public let PUBLICATION_MANAGEMENT_CANISTER_ID = "kq23y-aiaaa-aaaaf-qajmq-cai";
   public let NFT_FACTORY_CANISTER_ID = "kc4mb-myaaa-aaaaf-qajpq-cai";
+  public let SNS_GOVERNANCE_CANISTER = "rzbmc-yiaaa-aaaaq-aabsq-cai";
+  public let PAUL_PRINCIPAL_ID = "keqno-ecosc-a47cf-rk2ui-5ehla-noflk-jj4it-h6nku-smno2-fucgs-cae";
+  public let MITCH_PRINCIPAL_ID = "3v3rk-jx25f-dl43p-osgkw-6dm7b-wguwy-kjcun-lyo3w-lsuev-kcdnp-7qe";
+  public let BARAN_PRINCIPAL_ID = "wvhee-rnvlo-p6u4o-6fm55-jmxlu-yy2yt-dx47v-rxswo-u7kuk-dofj5-aae";
+  public let NICK_PRINCIPAL_ID = "lak3h-wosi7-pjqxd-fpluz-2etul-g7zza-fvm56-tz3sc-efctb-a3qp6-2qe";
+
+  public let PLATFORM_OPERATORS = [
+    PAUL_PRINCIPAL_ID,
+    MITCH_PRINCIPAL_ID,
+    BARAN_PRINCIPAL_ID,
+    NICK_PRINCIPAL_ID
+  ];
+
+  public func isPlatformOperator(caller: Principal) : Bool{
+    let c = Principal.toText(caller);
+    for(operator in PLATFORM_OPERATORS.vals()){
+      if(operator == c){
+        return true;
+      }
+    };
+    return false
+  };
+
+  public let CYCLES_DISPENSER_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    POST_CORE_CANISTER_ID
+  ];
+
+  public let FASTBLOCKS_EMAIL_OPT_IN_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID
+  ];
+
+  public let KINIC_ENDPOINT_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID
+  ];
+
+  public let METRICS_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    POST_CORE_CANISTER_ID
+  ];
+
+  public let POSTBUCKET_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    POST_CORE_CANISTER_ID,
+    PUBLICATION_MANAGEMENT_CANISTER_ID,
+    USER_CANISTER_ID
+  ];
+
+  public let POSTCORE_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    USER_CANISTER_ID,
+    PUBLICATION_MANAGEMENT_CANISTER_ID
+  ];
+
+  public let POSTINDEX_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    POST_CORE_CANISTER_ID
+  ];
+
+  public let STORAGE_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID
+  ];
+
+  public let USER_CANISTER_ADMINS = [
+    SNS_GOVERNANCE_CANISTER,
+    CYCLES_DISPENSER_CANISTER_ID,
+    USER_CANISTER_ID,
+    PUBLICATION_MANAGEMENT_CANISTER_ID
+  ];
+
+
+
 };


### PR DESCRIPTION
This PR includes some breaking changes explained in 3 items:

1. Admin & platformOperator logic
Hard coded all the canister ids and 4 platform operators (Mitch, Paul, Nick and Baran) in the env.mo file. So, the admins and platform operators are hard coded in the env.mo dile and they can only be changed by a code change proposal.

2. Storing the canister ids:
Canisters making cross-canister calls was storing the other canister ids in a stable variable. With the latest changes, since all canister ids are hardcoded in the env.mo file, there is no need for these variables. The CanisterDeclarations.mo file uses canister ids by importing them directly from the env.mo file.

3. devInstall script changes:
Since we don't need the registerAdmin functionality anymore (it's hardcoded in the env file), needed to update the devinstall script.