### PR TITLE
1342-bucket-canister-controller-migration

### DIFF
--- a/Nuance-NFTs-and-Publications/src/publication-management/ic.types.mo
+++ b/Nuance-NFTs-and-Publications/src/publication-management/ic.types.mo
@@ -1,60 +1,63 @@
-// Source: motoko playground
-// https://github.com/dfinity/motoko-playground/blob/3cf294725acf2213ca5e7c01bc59115781ab8ac4/service/pool/IC.mo
+import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
+import Principal "mo:base/Principal";
 
-// Also update controllers instead of controller according doc https://sdk.dfinity.org/docs/interface-spec/index.html#ic-interface-overview
+import Blob "mo:base/Blob";
 
 module {
-    public type canister_id = Principal;
-    public type canister_settings = {
-        controllers : ?[Principal];
-        freezing_threshold : ?Nat;
-        memory_allocation : ?Nat;
-        compute_allocation : ?Nat;
-    };
-    public type definite_canister_settings = {
-        controllers : ?[Principal];
-        freezing_threshold : Nat;
-        memory_allocation : Nat;
-        compute_allocation : Nat;
-    };
-    public type user_id = Principal;
-    public type wasm_module = Blob;
-    public type canister_status_response = {
-        status : { #stopped; #stopping; #running };
-        memory_size : Nat;
-        cycles : Nat;
-        settings : definite_canister_settings;
-        module_hash : ?Blob;
-    };
 
-    public type Self = actor {
-        canister_status : shared query { canister_id : canister_id } -> async canister_status_response;
-        create_canister : shared { settings : ?canister_settings } -> async {
-            canister_id : canister_id;
-        };
-        delete_canister : shared { canister_id : canister_id } -> async ();
-        deposit_cycles : shared { canister_id : canister_id } -> async ();
-        install_code : shared {
-            arg : [Nat8];
-            wasm_module : wasm_module;
-            mode : { #reinstall; #upgrade; #install };
-            canister_id : canister_id;
-        } -> async ();
-        provisional_create_canister_with_cycles : shared {
-            settings : ?canister_settings;
-            amount : ?Nat;
-        } -> async { canister_id : canister_id };
-        provisional_top_up_canister : shared {
-            canister_id : canister_id;
-            amount : Nat;
-        } -> async ();
-        raw_rand : shared () -> async Blob;
-        start_canister : shared { canister_id : canister_id } -> async ();
-        stop_canister : shared { canister_id : canister_id } -> async ();
-        uninstall_code : shared { canister_id : canister_id } -> async ();
-        update_settings : shared {
-            canister_id : Principal;
-            settings : canister_settings;
-        } -> async ();
+public type canister_id = Principal;
+  public type canister_settings = {
+    freezing_threshold : ?Nat;
+    controllers : ?[Principal];
+    memory_allocation : ?Nat;
+    compute_allocation : ?Nat;
+  };
+  public type definite_canister_settings = {
+    freezing_threshold : Nat;
+    controllers : [Principal];
+    memory_allocation : Nat;
+    compute_allocation : Nat;
+  };
+  public type user_id = Principal;
+  public type wasm_module = Blob;
+
+
+  public let IC = actor "aaaaa-aa" : actor {
+    canister_status : shared { canister_id : canister_id } -> async {
+      status : { #stopped; #stopping; #running };
+      memory_size : Nat;
+      cycles : Nat;
+      settings : definite_canister_settings;
+      module_hash : ?[Nat8];
     };
+    create_canister : shared { settings : ?canister_settings } -> async {
+      canister_id : canister_id;
+    };
+    delete_canister : shared { canister_id : canister_id } -> async ();
+    deposit_cycles : shared { canister_id : canister_id } -> async ();
+    install_code : shared {
+        arg : [Nat8];
+        wasm_module : wasm_module;
+        mode : { #reinstall; #upgrade; #install };
+        canister_id : canister_id;
+      } -> async ();
+    provisional_create_canister_with_cycles : shared {
+        settings : ?canister_settings;
+        amount : ?Nat;
+      } -> async { canister_id : canister_id };
+    provisional_top_up_canister : shared {
+        canister_id : canister_id;
+        amount : Nat;
+      } -> async ();
+    raw_rand : shared () -> async [Nat8];
+    start_canister : shared { canister_id : canister_id } -> async ();
+    stop_canister : shared { canister_id : canister_id } -> async ();
+    uninstall_code : shared { canister_id : canister_id } -> async ();
+    update_settings : shared {
+        canister_id : Principal;
+        settings : canister_settings;
+      } -> async ();
+    };
+ 
 };

--- a/Nuance-NFTs-and-Publications/src/publication-management/main.mo
+++ b/Nuance-NFTs-and-Publications/src/publication-management/main.mo
@@ -114,7 +114,7 @@ actor class Management() = this {
 
     for (bucketCanisterId in publicationCanisterIdsHashmap.vals()) {
     
-    Debug.print("Updating settings for canister: " # bucketCanisterId);
+   
       
       let status = await ic.canister_status({ canister_id = Principal.fromText(bucketCanisterId); });
       let controllers = status.settings.controllers;
@@ -124,15 +124,13 @@ actor class Management() = this {
       for (controller in controllers.vals()) {
         if (Principal.toText(controller).size() < 28) {
         controllersBuffer.add(controller);
-        Debug.print("Adding controller: " # Principal.toText(controller));
+        
         }
       };
 
       controllersBuffer.add(Principal.fromActor(this));
       controllersBuffer.add(Principal.fromText(ENV.SNS_GOVERNANCE_CANISTER));
-
-
-    Debug.print("Updating settings for canister: " # bucketCanisterId # " with controllers: " # debug_show( Buffer.toArray(controllersBuffer)));
+      
       switch (await ic.update_settings(({ canister_id = Principal.fromText(bucketCanisterId); settings = { 
         controllers = ?Buffer.toArray(controllersBuffer);
         freezing_threshold = null;

--- a/src/PostBucket/main.mo
+++ b/src/PostBucket/main.mo
@@ -982,7 +982,7 @@ actor class PostBucket() = this {
 
         switch (publicationReturn) {
           case (#ok(pub)) {
-            if (not U.arrayContains(pub.editors, callerHandle)) {
+            if (not U.arrayContains(pub.editors, U.lowerCase(callerHandle))) {
               return #err(Unauthorized);
             } else if (rejectedByModClub(postId)) {
               return #err(RejectedByModerators);

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -1810,10 +1810,6 @@ actor PostCore {
 
   };
 
-  //debugging method that returns all the moderation related data
-  public shared query func debugGetModeration() : async ([(Text, Nat)], [(Text, PostModerationStatus)]) {
-    (Iter.toArray(postVersionMap.entries()), Iter.toArray(postModerationStatusMap.entries()));
-  };
 
   public shared ({ caller }) func handleModclubMigration(postCanisterId : Text) : async Result.Result<Text, Text> {
     if (isAnonymous(caller)) {

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -2552,7 +2552,7 @@ actor PostCore {
     let postIdWithVersion = getPostIdWithVersionId(postId, versionId);
     // On local, don't send posts to Modclub
     if (environment != "local") {
-      let _ = await MC.getModClubActor(environment).submitHtmlContent(postIdWithVersion, "<img style='max-height: 500px; max-width: 500px;' src='" # postModel.headerImage # "' />" # postModel.content, ?postModel.title, null);
+      let _ = await MC.getModClubActor(environment).submitHtmlContent(postIdWithVersion, "<img style='max-height: 500px; max-width: 500px;' src='" # postModel.headerImage # "' />" # postModel.content, ?postModel.title, null, null);
     };
     postModerationStatusMap.put(postIdWithVersion, #reviewRequired);
   };

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -206,7 +206,6 @@ actor PostCore {
 
       for (controller in controllers.vals()) {
         if (Principal.toText(controller).size() < 28) {
-        Debug.print("controller: " # Principal.toText(controller) # "length: " # Nat.toText(Principal.toText(controller).size()));
         controllersBuffer.add(controller);
         }
       };
@@ -283,14 +282,14 @@ actor PostCore {
         case (_) {};
       };
 
-      Debug.print("Newly created bucket canister canister id is " # canisterId);
+      
 
       try {
         //authorize bucket canister in frontend canister
         let frontendActor = CanisterDeclarations.getFrontendCanister();
-        Debug.print("frontend actor defined successfully");
+       
         await frontendActor.authorize(Principal.fromActor(bucketCanister));
-        Debug.print("frontend actor authorize went succesful");
+        
       } catch (e) {
         Debug.print("authorize error");
       };

--- a/src/PostCore/modclub/modclub.mo
+++ b/src/PostCore/modclub/modclub.mo
@@ -77,7 +77,7 @@ module {
     updateSettings : (ProviderSettings) -> async ();
     submitText : (Text, Text, ?Text) -> async Text;
     submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-    submitHtmlContent : (Text, Text, ?Text, ?Level) -> async Text;
+     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
     subscribe : (SubscribeMessage) -> async ();
     // Proof of Humanity APIs
     pohVerificationRequest : (Principal) -> async PohVerificationResponse;
@@ -94,7 +94,7 @@ module {
     updateSettings : (ProviderSettings) -> async ();
     submitText : (Text, Text, ?Text) -> async Text;
     submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-    submitHtmlContent : (Text, Text, ?Text, ?Level) -> async Text;
+     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
     subscribe : (SubscribeMessage) -> async ();
     // Proof of Humanity APIs
     pohVerificationRequest : (Principal) -> async PohVerificationResponse;
@@ -111,7 +111,7 @@ module {
     updateSettings : (ProviderSettings) -> async ();
     submitText : (Text, Text, ?Text) -> async Text;
     submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-    submitHtmlContent : (Text, Text, ?Text, ?Level) -> async Text;
+     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
     subscribe : (SubscribeMessage) -> async ();
     // Proof of Humanity APIs
     pohVerificationRequest : (Principal) -> async PohVerificationResponse;

--- a/src/nuance_assets/UI/meatball-menu/meatball-menu.tsx
+++ b/src/nuance_assets/UI/meatball-menu/meatball-menu.tsx
@@ -95,13 +95,13 @@ const MeatBallMenu: React.FC<MeatBallMenuProps> = (props): JSX.Element => {
         style={
           props.shown
             ? {
-                height: isLoggedIn ? '250px' : '290px',
-                boxShadow: '0px 2px 10px 5px rgba(117, 117, 117, 0.08)',
-                color: darkTheme
-                  ? colors.primaryBackgroundColor
-                  : colors.primaryTextColor,
-                backgroundColor: darkTheme ? colors.primaryTextColor : '',
-              }
+              height: isLoggedIn ? '250px' : '290px',
+              boxShadow: '0px 2px 10px 5px rgba(117, 117, 117, 0.08)',
+              color: darkTheme
+                ? colors.primaryBackgroundColor
+                : colors.primaryTextColor,
+              backgroundColor: darkTheme ? colors.primaryTextColor : '',
+            }
             : { display: 'none' }
         }
       >
@@ -114,13 +114,6 @@ const MeatBallMenu: React.FC<MeatBallMenuProps> = (props): JSX.Element => {
               <li style={darkOptionsAndColors}>Login/register</li>
             </a>
           )}
-          <a
-            href='https://home.nuance.xyz'
-            target='_blank'
-            style={darkOptionsAndColors}
-          >
-            <li style={darkOptionsAndColors}>About</li>
-          </a>
           <a
             href='https://aikin.gitbook.io/nuance/'
             target='_blank'

--- a/src/nuance_assets/screens/category-landing/_category-landing.scss
+++ b/src/nuance_assets/screens/category-landing/_category-landing.scss
@@ -1,49 +1,55 @@
 .publication-name-category {
     position: absolute;
-    top: 30%;
-    left: 5%;
-    background-color: #4c4c52;
+    bottom: 33px;
+    left: 5.9vw;
+    
     color: #fff;
-    font-size: 3em;
+    font-size: clamp(40px, 7vw, 70px);
     font-family: Roboto;
-    padding-left: 10px;
-    padding-right: 40px;
+   
   }
 
   .publication-handle-category {
     position: absolute;
-    top: 70%;
-    left: 5%;
-    background-color: #4c4c52;
+    bottom: 10px;
+      left: 5.5vw;
+   
     color: #e6e6e6;
-    font-size: 0.7em;
+    font-size: clamp(12px, 1.2vw, 12px);
     font-family: Roboto;
-    padding-left: 10px;
-    padding-right: 40px;
+   
+    .at-handle{
+      padding-left: 11px;
+    }
   }
 
   .category-element.selected {
     font-weight: bold;
   }
 
+  .publication-name-category,  .publication-handle-category {
+    position: absolute;
+    left: 5%; 
+    z-index: 2; 
+  }
+
   
 @media only screen and (max-width: 1089px) {
     .publication-name-category{
-        font-size: 1.8em;
+        
     }
     .publication-handle-category{
-        font-size: 0.6em;
-        top: 56%;
+       
+        
     }
   }
 
   @media only screen and (max-width: 557px) {
     .publication-name-category{
-      top: 125px;
-      font-size: 1.2rem;
+     
     }
     .publication-handle-category{
-        top: 160px;
+       
     }
   }
 

--- a/src/nuance_assets/screens/category-landing/_category-landing.scss
+++ b/src/nuance_assets/screens/category-landing/_category-landing.scss
@@ -1,22 +1,24 @@
 .publication-name-category {
     position: absolute;
-    bottom: 33px;
+    bottom: 53px;
     left: 5.9vw;
     
     color: #fff;
     font-size: clamp(40px, 7vw, 70px);
     font-family: Roboto;
+    font-weight: 300;
    
   }
 
   .publication-handle-category {
     position: absolute;
-    bottom: 10px;
+    bottom: 30px;
       left: 5.5vw;
    
     color: #e6e6e6;
     font-size: clamp(12px, 1.2vw, 12px);
     font-family: Roboto;
+    font-weight: 700;
    
     .at-handle{
       padding-left: 11px;

--- a/src/nuance_assets/screens/category-landing/category-landing.tsx
+++ b/src/nuance_assets/screens/category-landing/category-landing.tsx
@@ -9,7 +9,7 @@ import {
 import Header from '../../components/header/header';
 import Footer from '../../components/footer/footer';
 import Loader from '../../UI/loader/Loader';
-import { images, colors } from '../../shared/constants';
+import { images, colors, icons } from '../../shared/constants';
 import CopyPublication from '../../UI/copy-publication/copy-publication';
 import ReportAuthorMenu from '../../UI/report-author/report-author';
 import FollowAuthor from '../../components/follow-author/follow-author';
@@ -106,9 +106,9 @@ function CategoryLanding() {
     if (
       publication !== undefined &&
       publication?.publicationHandle.toLowerCase() !==
-        current_location
-          .substring(13, current_location.lastIndexOf('/'))
-          .toLowerCase()
+      current_location
+        .substring(13, current_location.lastIndexOf('/'))
+        .toLowerCase()
     ) {
       setPublicationDoesNotExist(true);
     }
@@ -199,7 +199,7 @@ function CategoryLanding() {
     setLoadingMore(false);
   };
 
-  const loadInitial = async (handle: string, category:string) => {
+  const loadInitial = async (handle: string, category: string) => {
     setPostsLoading(true);
     setTimeout(() => {
       setPostsLoading(false);
@@ -369,7 +369,7 @@ function CategoryLanding() {
               style={{ width: '100%', height: '200px', objectFit: 'cover' }}
               src={`${publication?.headerImage}`}
             />
-            <div className='nuance-publication'>A Nuance Publication</div>
+            <div className='nuance-publication'>A NUANCE PUBLICATION</div>
             <div className='publication-name-category'>
               {publication?.publicationTitle}
             </div>
@@ -379,8 +379,14 @@ function CategoryLanding() {
                   style={{ width: '35px', padding: '5px', borderRadius: '50%' }}
                   src={`${publication?.avatar}` || images.DEFAULT_AVATAR}
                 />
+                <img
+                  src={icons.PUBLICATION_ICON}
+                  alt='publication-icon'
+                  className='publication-header-icon'
+                />
+
               </span>
-              <span>@</span>
+              <span className='at-handle'>@</span>
               {publication?.publicationHandle}
             </div>
           </div>

--- a/src/nuance_assets/screens/category-landing/category-landing.tsx
+++ b/src/nuance_assets/screens/category-landing/category-landing.tsx
@@ -369,7 +369,6 @@ function CategoryLanding() {
               style={{ width: '100%', height: '200px', objectFit: 'cover' }}
               src={`${publication?.headerImage}`}
             />
-            <div className='nuance-publication'>A NUANCE PUBLICATION</div>
             <div className='publication-name-category'>
               {publication?.publicationTitle}
             </div>

--- a/src/nuance_assets/screens/publication-landing/publication-landing.scss
+++ b/src/nuance_assets/screens/publication-landing/publication-landing.scss
@@ -5,6 +5,7 @@
   min-height: 100vh;
   .left {
     width: 24%;
+    max-width: 250px;
     .left-content {
       margin-top: 0;
       display: flex;

--- a/src/nuance_assets/screens/publication-landing/publication-landing.scss
+++ b/src/nuance_assets/screens/publication-landing/publication-landing.scss
@@ -45,6 +45,7 @@
   }
 
   .right {
+    max-width: 1170px;
     width: 76%;
     .article-list {
       border-left: 1px solid #c4c4c4;
@@ -66,55 +67,102 @@
   .header-image-container {
     position: relative;
     text-align: center;
-    .header-img{
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        0deg, 
+        rgba(0, 0, 0, 0.80) 0%, 
+        rgba(0, 0, 0, 0.00) 100%
+      );
+      pointer-events: none; 
+    }
+  
+    .header-img {
       width: 100%;
       max-height: 480px;
+      min-height:408px;
       object-fit: cover;
+    }
+
+    .nuance-publication, .publication-name, .publication-subtitle, .publication-handle {
+      position: absolute;
+      left: 5%; 
+      z-index: 2; 
+    }
+
+    .nuance-publication {
+      position: absolute;
+      top: 20px;
+      left: 5.6vw;
+      color: #999999;
+      font-size: clamp(12px, 1.2vw, 14px);
+      font-style: normal;
+      font-weight: 700;
+      line-height: 24px;
+    }
+  
+    .publication-name {
+      position: absolute;
+      bottom: 141px;
+      left: 6.4vw;
+      color: #fff;
+      font-size: clamp(50px, 7vw, 70px);
+      font-style: normal;
+      font-weight: 300;
+      line-height: 5vh; 
+      font-family: Roboto;
+     
+     
+    }
+  
+    .publication-subtitle {
+      position: absolute;
+      bottom: 94px;
+      left: 7vw;
+  
+      color: #d9d9d9;
+      font-size: clamp(12px, 1.8vw, 18px);
+      font-style: normal;
+      padding-top: 5px;
+      padding-bottom: 5px;
+      font-weight: 400;
+      line-height: 2.6vh;
+      font-family: Roboto;
+    }
+  
+    .publication-handle {
+      position: absolute;
+      bottom: 36px;
+      left: 7vw;
+      color: #e6e6e6;
+      font-size: clamp(12px, 1.2vw, 12px);
+      font-style: normal;
+      font-weight: 700;
+      line-height: 2.4vh;
+      font-family: Roboto;
+      margin-left: -5px;
+
+      .at-handle{
+        padding-left: 11px;
+      }
+      
     }
   }
 
-  .nuance-publication {
-    position: absolute;
-    top: 10%;
-    left: 5%;
-    color: #999999;
+  .publication-header-icon {
+    width: 8px;
+    height: 8px;
+    margin-left: -13px;
+    margin-top: 18px;
   }
+  
 
-  .publication-name {
-    position: absolute;
-    top: 32%;
-    left: 5%;
-    background-color: #4c4c52;
-    color: #fff;
-    font-size: 3em;
-    font-family: Roboto;
-    padding-left: 10px;
-    padding-right: 40px;
-  }
-
-  .publication-subtitle {
-    position: absolute;
-    top: 48%;
-    left: 5%;
-    background-color: #4c4c52;
-    color: #d9d9d9;
-    font-size: 1em;
-    font-family: Roboto;
-    padding-left: 10px;
-    padding-right: 40px;
-  }
-
-  .publication-handle {
-    position: absolute;
-    top: 54%;
-    left: 5%;
-    background-color: #4c4c52;
-    color: #e6e6e6;
-    font-size: 0.7em;
-    font-family: Roboto;
-    padding-left: 10px;
-    padding-right: 40px;
-  }
+ 
 
   .article-grid-large {
     margin-left: 0;
@@ -216,21 +264,7 @@
         }
       }
     }
-    .publication-name {
-      font-size: 2em;
-      top: 66%;
-      left: 5%;
-    }
-  
-    .publication-subtitle {
-      top: 78%;
-      left: 5%;
-    }
-  
-    .publication-handle {
-      top: 85%;
-      left: 5%;
-    }
+    
   }
 }
 
@@ -247,18 +281,7 @@
       }
       
     }
-    .publication-handle {
-      font-size: 0.5em;
-      top: 160px;
-    }
-    .publication-subtitle {
-      font-size: 0.9em;
-      top: 135px;
-    }
-    .publication-name {
-      top: 104px;
-      font-size: 1.2em;
-    }
+    
   }
   .right{
     .header-image-container{

--- a/src/nuance_assets/screens/publication-landing/publication-landing.scss
+++ b/src/nuance_assets/screens/publication-landing/publication-landing.scss
@@ -109,13 +109,14 @@
     .publication-name {
       position: absolute;
       bottom: 141px;
-      left: 6.4vw;
+      left: 7vw;
       color: #fff;
       font-size: clamp(50px, 7vw, 70px);
       font-style: normal;
       font-weight: 300;
       line-height: 5vh; 
       font-family: Roboto;
+      margin: 0px -5px;
      
      
     }

--- a/src/nuance_assets/screens/publication-landing/publication-landing.tsx
+++ b/src/nuance_assets/screens/publication-landing/publication-landing.tsx
@@ -10,7 +10,7 @@ import Header from '../../components/header/header';
 import Footer from '../../components/footer/footer';
 import SearchBar from '../../components/search-bar/search-bar';
 import Loader from '../../UI/loader/Loader';
-import { images, colors } from '../../shared/constants';
+import { images, colors, icons } from '../../shared/constants';
 import './publication-landing.scss';
 import CopyPublication from '../../UI/copy-publication/copy-publication';
 import ReportAuthorMenu from '../../UI/report-author/report-author';
@@ -239,7 +239,7 @@ function PublicationLanding() {
 
   const loadInitial = async (handle: string) => {
     setInitialPostsLoading(true);
-    setTimeout(()=>{
+    setTimeout(() => {
       setInitialPostsLoading(false);
     }, 5000)
     let posts = await getPostsByFollowers([handle], 0, 7);
@@ -395,7 +395,7 @@ function PublicationLanding() {
   if (
     !publication?.publicationHandle ||
     publication.publicationHandle.toLowerCase() !==
-      getPublicationHandleFromUrl().toLowerCase()
+    getPublicationHandleFromUrl().toLowerCase()
   ) {
     return (
       <div style={{ background: darkOptionsAndColors.background }}>
@@ -452,15 +452,15 @@ function PublicationLanding() {
                 style={
                   !isSidebarToggled && screenWidth <= 1089
                     ? {
-                        marginRight: '180px',
-                        width: '150px',
-                        height: '47.5px',
-                      }
+                      marginRight: '180px',
+                      width: '150px',
+                      height: '47.5px',
+                    }
                     : {
-                        marginRight: '15px',
-                        width: '150px',
-                        height: '47.5px',
-                      }
+                      marginRight: '15px',
+                      width: '150px',
+                      height: '47.5px',
+                    }
                 }
                 className='brand-logo-left'
                 src={publication?.styling.logo}
@@ -543,7 +543,7 @@ function PublicationLanding() {
           <div className='header-image-container'>
             <img src={`${publication?.headerImage}`} className='header-img' />
 
-            <div className='nuance-publication'>A Nuance Publication</div>
+            <div className='nuance-publication'>A NUANCE PUBLICATION</div>
             <div className='publication-name'>
               {publication?.publicationTitle}
             </div>
@@ -554,8 +554,14 @@ function PublicationLanding() {
                   style={{ width: '35px', padding: '5px', borderRadius: '50%' }}
                   src={`${publication?.avatar}` || images.DEFAULT_AVATAR}
                 />
+                <img
+                  src={icons.PUBLICATION_ICON}
+                  alt='publication-icon'
+                  className='publication-header-icon'
+                />
+
               </span>
-              <span>@</span>
+              <span className='at-handle'>@</span>
               {publication?.publicationHandle}
             </div>
           </div>
@@ -597,8 +603,8 @@ function PublicationLanding() {
             <Footer />
           </div>
         </div>
-      </div>
-    </div>
+      </div >
+    </div >
   );
 }
 


### PR DESCRIPTION
This change will remove team member controller privileges on all bucket canisters. In some cases, canisters are controlled by various other core canisters; I've ensured that these will remain and only team principals will be removed. In addition, the SNS governance canister is now added at creation and as a part of the migration. 

Commands to Test:
`dfx canister call PublicationManagement updateSettingsForAllBucketCanisters`
`dfx canister call PostCore updateSettingsForAllBucketCanisters`

Also, upon a fresh dev install, SNS governance canister will be added by default. 


Edit:

Now includes 
* `1417 modclub interface bug`
* `1405 removed about from nav menu` . 
*  `1400 unauthorized on create article screen after editor saving as draft`
* `1416 publication header gradient` 