### PR TITLE
Page widths updated for all screens

### DIFF
--- a/src/nuance_assets/App.tsx
+++ b/src/nuance_assets/App.tsx
@@ -95,6 +95,8 @@ const logo = `https://nuance.xyz/logo.png`;
 function App() {
   //handle resize on app wide
   const context = useContext(Context);
+  const darkTheme = useTheme();
+
   const handleResize = () => {
     let width = window.innerWidth;
     let height = window.innerHeight;
@@ -105,6 +107,13 @@ function App() {
     window.addEventListener('resize', handleResize);
     fetchTokenBalances()
   }, []);
+
+  useEffect(() => {
+    document.body.style.backgroundColor = darkTheme
+      ? 'var(--dark-primary-background-color)'
+      : colors.primaryBackgroundColor;
+  }, [darkTheme]);
+
 
   const inactivityTimeout: number = //process.env.II_INACTIVITY_TIMEOUT
     //   ? // configuration is in minutes, but API expects milliseconds
@@ -142,82 +151,82 @@ function App() {
   //   }
   // }, [isLoggedIn]);
 
-  const darkTheme = useTheme();
+
 
   return (
     <ModalContextProvider>
-      <ThemeProvider>
-        <div className='App'>
-          <Helmet>
-            <meta charSet='utf-8' />
-            <link
-              rel='canonical'
-              href={'https://nuance.xyz' + window.location.pathname}
-            />
-            <link rel='icon' href='/favicon.ico' type='image/x-icon' />
-            <meta
-              name='viewport'
-              content='width=device-width, initial-scale=1.0'
-            />
 
-            {/* HTML Meta Tags */}
-            <title>{siteTitle}</title>
-            <meta name='description' content={siteDesc} />
-
-            {/* Google / Search Engine Tags */}
-            <meta itemProp='name' content={siteTitle} />
-            <meta itemProp='description' content={siteDesc} />
-            <meta itemProp='image' content={logo} />
-
-            {/* Facebook Meta Tags */}
-            <meta property='og:title' content={siteTitle} />
-            <meta property='og:description' content={siteDesc} />
-            <meta property='og:url' content='https://nuance.xyz/' />
-            <meta property='og:type' content='website' />
-            <meta property='og:image' content={logo} />
-
-            {/* Twitter Meta Tags */}
-            <meta name='twitter:card' content={logo} />
-            <meta name='twitter:card' content={'summary_large_image'} />
-            <meta name='twitter:title' content={siteTitle} />
-            <meta name='twitter:description' content={siteDesc} />
-            <meta name='twitter:image' content={logo} />
-            <meta name='twitter:creator' content='@nuancedapp' />
-          </Helmet>
-          <Router>
-            <Suspense
-              fallback={
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    height: '100vh',
-                    width: '100vw',
-                    background: darkTheme
-                      ? colors.darkModePrimaryBackgroundColor
-                      : colors.primaryBackgroundColor,
-                  }}
-                >
-                  <Loader />
-                </div>
-              }
-            >
-              <Routes />
-            </Suspense>
-          </Router>
-          <Toaster
-            position='bottom-center'
-            toastOptions={{
-              style: {
-                backgroundColor: '#000000',
-                color: '#ffffff',
-              },
-            }}
+      <div className='App'>
+        <Helmet>
+          <meta charSet='utf-8' />
+          <link
+            rel='canonical'
+            href={'https://nuance.xyz' + window.location.pathname}
           />
-          <ModalsWrapper/>
-        </div>
-      </ThemeProvider>
+          <link rel='icon' href='/favicon.ico' type='image/x-icon' />
+          <meta
+            name='viewport'
+            content='width=device-width, initial-scale=1.0'
+          />
+
+          {/* HTML Meta Tags */}
+          <title>{siteTitle}</title>
+          <meta name='description' content={siteDesc} />
+
+          {/* Google / Search Engine Tags */}
+          <meta itemProp='name' content={siteTitle} />
+          <meta itemProp='description' content={siteDesc} />
+          <meta itemProp='image' content={logo} />
+
+          {/* Facebook Meta Tags */}
+          <meta property='og:title' content={siteTitle} />
+          <meta property='og:description' content={siteDesc} />
+          <meta property='og:url' content='https://nuance.xyz/' />
+          <meta property='og:type' content='website' />
+          <meta property='og:image' content={logo} />
+
+          {/* Twitter Meta Tags */}
+          <meta name='twitter:card' content={logo} />
+          <meta name='twitter:card' content={'summary_large_image'} />
+          <meta name='twitter:title' content={siteTitle} />
+          <meta name='twitter:description' content={siteDesc} />
+          <meta name='twitter:image' content={logo} />
+          <meta name='twitter:creator' content='@nuancedapp' />
+        </Helmet>
+        <Router>
+          <Suspense
+            fallback={
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  height: '100vh',
+                  width: '100vw',
+                  background: darkTheme
+                    ? colors.darkModePrimaryBackgroundColor
+                    : colors.primaryBackgroundColor,
+                }}
+              >
+                <Loader />
+              </div>
+            }
+          >
+            <Routes />
+          </Suspense>
+        </Router>
+        <Toaster
+          position='bottom-center'
+          toastOptions={{
+            style: {
+              backgroundColor: '#000000',
+              color: '#ffffff',
+            },
+          }}
+        />
+        <ModalsWrapper />
+      </div>
+
     </ModalContextProvider>
   );
 }

--- a/src/nuance_assets/components/card-large/_card-large.scss
+++ b/src/nuance_assets/components/card-large/_card-large.scss
@@ -3,7 +3,7 @@
 
 .article-grid-large {
   .card-wrapper-large {
-    width: 95%;
+    max-width: 825px; 
     object-fit: cover;
     overflow: hidden;
     .main-pic-large {
@@ -87,8 +87,11 @@
 
 @media only screen and (max-width: 768px) {
   .article-grid-large {
+    margin-left: 0px;
+      margin-right: 0px;
     .card-wrapper-large {
-      width: 100%;
+      margin-left: 0px;
+      margin-right: 0px;
       .main-pic-large {
         &:hover {
           transform: none;

--- a/src/nuance_assets/components/card-vertical/_card-vertical.scss
+++ b/src/nuance_assets/components/card-vertical/_card-vertical.scss
@@ -5,12 +5,11 @@
   position: relative;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  column-gap: 12px;
-  row-gap: 50px;
-  margin-right: 50px;
+  column-gap: 76px; 
+  row-gap: 50px; 
   margin-top: 65px;
   .card-wrapper {
-    width: 88%;
+    width: 100%;
     object-fit: cover;
     overflow: hidden;
     .main-pic {
@@ -95,11 +94,9 @@
 
 @media only screen and (max-width: 768px) {
   .article-grid {
-    display: grid;
     grid-template-columns: 1fr;
-    row-gap: 0px;
-    column-gap: 50px;
-    //margin: 65px -40px 0 -20px;
+    row-gap: 76px;
+    column-gap: 0;
     .card-wrapper {
       .main-pic {
         &:hover {

--- a/src/nuance_assets/components/comments/_comments.scss
+++ b/src/nuance_assets/components/comments/_comments.scss
@@ -89,7 +89,7 @@
 
             }
 
-            .text {
+            .comment-text {
                 font-size: 12px;
                 font-weight: 400;
                 line-height: 18px;
@@ -98,7 +98,7 @@
             @media (max-width: 1089px) {
                 padding: 0px;
 
-                .text {
+                .comment-text {
                     display: none; // Hide the text span
                 }
 

--- a/src/nuance_assets/components/comments/comments.tsx
+++ b/src/nuance_assets/components/comments/comments.tsx
@@ -8,7 +8,7 @@ import { usePostStore } from '../../store/postStore';
 import { useAuthStore, useUserStore } from '../../../nuance_assets/store';
 import { Context } from '../../contextes/Context';
 import { useTheme } from '../../contextes/ThemeContext';
-import {Context as ModalContext} from '../../contextes/ModalContext'
+import { Context as ModalContext } from '../../contextes/ModalContext'
 import { Link } from 'react-router-dom';
 import { ToastType, toastError, toast } from '../..//services/toastService';
 
@@ -240,7 +240,7 @@ const Comments: React.FC<CommentProps> = ({
                       alt='Edit'
                       src={icons.EDIT_COMMENT}
                     />
-                    <span className='text'>Edit</span>
+                    <span className='comment-text'>Edit</span>
                   </button>
                 )}
                 <button
@@ -253,7 +253,7 @@ const Comments: React.FC<CommentProps> = ({
                     alt='Thumbs up'
                     src={icons.THUMBS_UP}
                   />
-                  <span className='text'>Thumbs up</span>
+                  <span className='comment-text'>Thumbs up</span>
                   {upVotesCount > 0 && `(${upVotesCount})`}
                 </button>
                 <button
@@ -266,17 +266,17 @@ const Comments: React.FC<CommentProps> = ({
                     alt='Thumbs down'
                     src={icons.THUMBS_DOWN}
                   />
-                  <span className='text'>Thumbs down</span>
+                  <span className='comment-text'>Thumbs down</span>
                   {downVotesCount > 0 && `(${downVotesCount})`}
                 </button>
 
                 <button className='reply-btn' onClick={handleReplyClick}>
                   <img className='icon' alt='reply' src={icons.REPLY} />
-                  <span className='text'>Reply</span>
+                  <span className='comment-text'>Reply</span>
                 </button>
                 <button className="share" onClick={handleShare}>
                   <img className='icon' alt='share' src={icons.SHARE} />
-                  <span className='text'>Share</span>
+                  <span className='comment-text'>Share</span>
                 </button>
 
               </div>

--- a/src/nuance_assets/components/follow-author/_follow-author.scss
+++ b/src/nuance_assets/components/follow-author/_follow-author.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   align-items: center;
   margin: 20px;
+  max-width: 715px;
 }
 .hideFollowButton {
   display: none;

--- a/src/nuance_assets/components/publication-categories-menu/_publication-categories-menu.scss
+++ b/src/nuance_assets/components/publication-categories-menu/_publication-categories-menu.scss
@@ -86,7 +86,7 @@
         margin-top: 20px;
         margin-bottom: 20px;
         align-self: center;
-        width: 120%;
+        width: 110%;
     }
 }
 

--- a/src/nuance_assets/contextes/Context.js
+++ b/src/nuance_assets/contextes/Context.js
@@ -19,6 +19,18 @@ const ContextProvider = ({ children }) => {
   const [width, setWidth] = useState(window.innerWidth);
   const [height, setHeight] = useState(window.innerHeight);
 
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+      setHeight(window.innerHeight);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Cleanup the event listener
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   const [profileSidebarDisallowed, setProfileSidebarDisallowed] = useState(false)
   
   return (

--- a/src/nuance_assets/index.scss
+++ b/src/nuance_assets/index.scss
@@ -70,11 +70,12 @@
 
 :root {
   --nua-blue: $primary-color;
+  --dark-primary-background-color: rgb(21, 20, 81);
+
 }
 
 body {
   margin: 0;
-  width: 100%;
   height: 100%;
   overflow-x: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/nuance_assets/index.tsx
+++ b/src/nuance_assets/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import reportWebVitals from './reportWebVitals';
 import { Usergeek } from 'usergeek-ic-js';
 import { ContextProvider } from './contextes/Context';
+import { ThemeProvider } from './contextes/ThemeContext';
 
 import './index.scss';
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
@@ -12,7 +13,9 @@ import App from './App';
 ReactDOM.render(
   <React.StrictMode>
     <ContextProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </ContextProvider>
   </React.StrictMode>,
   document.getElementById('root')

--- a/src/nuance_assets/screens/home/_homegrid.scss
+++ b/src/nuance_assets/screens/home/_homegrid.scss
@@ -1,5 +1,8 @@
 .homepage-wrapper {
   font-family: 'Roboto';
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   .main {
     display: grid;
@@ -8,6 +11,7 @@
     column-gap: 50px;
     width: 100vw;
     min-height: 100vh;
+    max-width: 1324px;
 
     &.blurred {
       -webkit-filter: blur(5px);
@@ -90,14 +94,6 @@
         padding: 0 auto;
       }
     }
-
-    // .right {
-    //   display: flex;
-    //   flex-direction: row;
-    //   text-align: left;
-    //   transition: ease-in 100ms;
-    //   margin: 0 auto;
-    // }
     .posts {
       margin-right: 100px;
 

--- a/src/nuance_assets/screens/publication-landing/publication-landing.scss
+++ b/src/nuance_assets/screens/publication-landing/publication-landing.scss
@@ -39,8 +39,7 @@
   }
 
   .publication-landing-cta{
-
-
+    max-width: 825px;
 
   }
 
@@ -121,13 +120,19 @@
     margin-right: 5%;
     margin-top: 15px;
     margin-left: 5%;
+    @media only screen and (max-width: 768px) {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
   .article-grid-horizontal {
     margin-left: 5%;
     margin-bottom: 10%;
+    max-width: 825px;
   }
   .article-grid {
     margin-left: 5%;
+    max-width: 825px;
   }
 }
 
@@ -208,8 +213,18 @@
       width: 100%;
 
       .article-list{
+        .article-grid-large{
+          .card-wrapper-large{
+            .publisher{
+              padding: 0px 20px 10px 20px;
+            }
+            .article-text{
+              padding: 0px 20px 10px 20px;
+            }
+          }
+        }
         .article-grid{
-          margin-left: 10%;
+       padding: 0px 10px;
         }
         .mainTitle{
           padding-top: 20px;
@@ -335,10 +350,24 @@
     .right {
       .latestArticles {
         width: 100%;
-        .article-grid-large {
-          width: 100%;
-          margin-left: 0;
-        }
+       
+         
+         
+
+        
+          .article-grid-large{
+            margin-left: 0;
+            margin-right: 0;
+          }
+            .card-wrapper-large{
+              .publisher{
+                padding: 0px 20px 10px 20px;
+              }
+              .article-text{
+                padding: 0px 20px 10px 20px;
+              }
+            }
+          
         .article-grid {
           margin-left: 3rem;
           margin-top: 1rem;

--- a/src/nuance_assets/screens/read-article/_read-article.scss
+++ b/src/nuance_assets/screens/read-article/_read-article.scss
@@ -2,22 +2,29 @@
 
 
 .read-article-wrapper {
+  width: 100vw;
+  margin: 0px;
   .page {
     display: flex;
-    justify-content: center;
+  
     margin: 50px 0 0 0;
-    width: 90%;
+    min-width: 90%;
     min-height: 100vh;
+    @media only screen and (min-width: 2000px) {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+    }
 
     .left {
       display: flex;
       flex-direction: column;
       align-items: flex-end;
       justify-items: flex-end;
-      width: 25%;
       border-right: 1px solid $light-border-color;
       padding-right: 20px;
       row-gap: 7px;
+      max-width: 340px;
 
       .date {
         display: flex;
@@ -30,7 +37,8 @@
       }
 
       .left-content {
-        width: 70%;
+        width: 100%;
+        max-width: 208px;
 
         .menus {
           display: flex;
@@ -76,11 +84,9 @@
     }
 
     .right {
-      width: 70%;
       margin-top: -20px;
 
       .content {
-        width: 85%;
 
         a:link {
           color: $link-color;
@@ -93,7 +99,8 @@
         }
 
         .title-post-info-wrapper {
-          padding: 0 0 0 91px;
+          padding: 0px 92px 0px 92px;
+          max-width: 915px;
 
           .nft-lock-icon {
             width: 30px;
@@ -113,10 +120,12 @@
 
         .header-content-wrapper {
           padding: 0 0 0 91px;
-          width: 120%;
+          width: 100%;
 
           .header-image {
-            height: 600px;
+            height: 578px;
+            max-width: 915px;
+            
             object-fit: cover;
             margin-left: -91px;
             width: -webkit-fill-available;
@@ -143,12 +152,14 @@
           }
 
           .text {
+            max-width: 715px;
+            padding-right: 35px;
+           
             a:visited {
               color: purple;
               font-size: 18px;
             }
 
-            width: 100%;
 
             a {
               color: $link-color ;
@@ -157,7 +168,7 @@
               font-size: 18px;
             }
 
-            ul li {
+            ul li ol {
               font-family: 'PT Serif';
               color: $primary-text-color ;
               font-size: 18px;
@@ -190,10 +201,6 @@
               padding-top: 50px;
             }
 
-            img {
-              max-width: 100%;
-              object-fit: contain;
-            }
 
             .text-image {
               img {
@@ -225,7 +232,7 @@
         }
 
         .profile-footer-wrapper {
-          padding: 0 0 0 91px;
+          padding: 0px 91px 0px 91px;
         }
 
       }
@@ -236,6 +243,7 @@
         justify-content: center;
         align-items: center;
         padding: 50px 0 10px 0;
+        max-width: 715px;
 
         .profile-picture {
           width: 96px;
@@ -289,10 +297,15 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
+  max-width: 715px;
 }
 
 
 .dark-text {
+
+  max-width: 715px;
+  padding-right: 91px;
+
   a:visited {
     color: purple;
     font-size: 18px;
@@ -359,7 +372,7 @@
 
 .comment-section {
   overflow-x: scroll;
-  max-width: 100%;
+  max-width: 715px;
 
   ::-webkit-scrollbar {
     display: none;
@@ -563,13 +576,14 @@
   }
 
   .read-article-wrapper {
-    width: 100%;
+    margin: 0px;
 
     .page {
       width: 100%;
       justify-content: flex-start;
 
       .left {
+       
         .date {
           margin: 0 -10px 0 0;
           width: max-content;
@@ -581,6 +595,7 @@
         }
 
         .left-menu {
+          max-width: 100%;
           display: flex;
           width: 100%;
         }
@@ -591,7 +606,7 @@
         margin-top: 20px;
 
         .content {
-          width: 85%;
+          
 
           h1 {
             font-size: 32px;
@@ -602,7 +617,7 @@
           }
 
           .title-post-info-wrapper {
-            padding: 0 0 0 35px;
+            padding: 0 35px 0 35px;
 
             .last-modified {
               font-size: 12px;
@@ -636,8 +651,15 @@
               object-fit: cover;
               height: 200px;
               margin-left: -35px;
-              width: -webkit-fill-available;
+             
+              
               background: white;
+            }
+
+            .dark-text {
+
+              max-width: 715px;
+              padding-right: 35px;
             }
 
             .text {
@@ -672,7 +694,8 @@
           }
 
           .profile-footer-wrapper {
-            padding: 0 0 0 35px;
+            padding: 0px 35px 0px 35px;
+            max-width: 715px;
           }
         }
 

--- a/src/nuance_assets/screens/read-article/read-article.tsx
+++ b/src/nuance_assets/screens/read-article/read-article.tsx
@@ -169,6 +169,22 @@ const ReadArticle = () => {
     return { postId, bucketCanisterId };
   };
 
+  const getLeftStyle = () => {
+    if (context.width <= 768) {
+      if (isToggled) {
+        return { width: 'max-content' };
+      } else {
+        return { width: '30px', paddingRight: '25px', maxWidth: '30px' };
+      }
+    } else {
+      if (context.width > 768) {
+        return { width: '25%' };
+      } else {
+        return { width: '30px', paddingRight: '25px', maxWidth: '30px' };
+      }
+    }
+  };
+
   const postId = separateIds(id as string).postId;
 
   const getTitleFromUrl = (url: string) => {
@@ -204,7 +220,6 @@ const ReadArticle = () => {
         navigate(`${location.pathname}`, { replace: true });
       }
     };
-
     if (commentId) {
       if (comments && comments.length > 0) {
         scrollToComment();
@@ -316,7 +331,7 @@ const ReadArticle = () => {
       () => {
         setScreenWidth(window.innerWidth);
       }),
-    [screenWidth]
+    [context.width]
   );
 
   const isSidebarToggled = (data: any) => {
@@ -360,7 +375,7 @@ const ReadArticle = () => {
         setButtonCount((prevCounter) => prevCounter + 1);
         clapPost(post?.postId || '');
         //ovation effect, user must hold button for 2 seconds for 10 claps total
-        if (screenWidth > 768 && user?.nuaTokens - buttoncount > 9) {
+        if (context.width > 768 && user?.nuaTokens - buttoncount > 9) {
           const interval = setInterval(() => {
             nineClaps();
             setButtonCount((prevCounter) => prevCounter + 9);
@@ -478,7 +493,7 @@ const ReadArticle = () => {
         loggedIn={isLoggedIn}
         isArticlePage={false}
         isReadArticlePage={true}
-        ScreenWidth={screenWidth}
+        ScreenWidth={context.width}
         tokens={user && user?.nuaTokens - buttoncount}
         loading={tokenAnimate}
         isPublicationPage={post?.isPublication}
@@ -494,13 +509,7 @@ const ReadArticle = () => {
       <div className='page'>
         <div
           className='left'
-          style={
-            screenWidth <= 768 && isToggled
-              ? { width: 'max-content' }
-              : screenWidth <= 768 && !isToggled
-              ? { width: '30px', paddingRight: '25px' }
-              : { width: '25%' }
-          }
+          style={getLeftStyle()}
         >
           <p className='date'>
             {formatDate(post?.publishedDate) || formatDate(post?.created)}{' '}
@@ -586,9 +595,9 @@ const ReadArticle = () => {
                 </ClapButton>
               </div>
               <div className='publication-email-opt-in' ref={refEmailOptIn}>
-                {screenWidth > 1089 && publicationHandle == 'FastBlocks' ? (
+                {context.width > 1089 && publicationHandle == 'FastBlocks' ? (
                   <EmailOptIn
-                    mobile={screenWidth < 1089}
+                    mobile={context.width < 1089}
                     publictionHandle={publicationHandle}
                   />
                 ) : null}
@@ -623,9 +632,9 @@ const ReadArticle = () => {
                   style={
                     post.isPublication
                       ? {
-                          fontFamily: publication?.styling.fontType,
-                          color: darkOptionsAndColors.color,
-                        }
+                        fontFamily: publication?.styling.fontType,
+                        color: darkOptionsAndColors.color,
+                      }
                       : { color: darkOptionsAndColors.color }
                   }
                   className='title'
@@ -636,7 +645,7 @@ const ReadArticle = () => {
                   post={post}
                   readTime={getReadTime()}
                   publication={publication}
-                  isMobile={screenWidth <= 768}
+                  isMobile={context.width <= 768}
                   handle={handle}
                 />
                 <h2 className='subtitle'>{post.subtitle}</h2>
@@ -756,9 +765,9 @@ const ReadArticle = () => {
                   isPublication={false}
                 />
                 <div className='publication-email-opt-in' ref={refEmailOptIn}>
-                  {screenWidth < 1089 && publicationHandle == 'FastBlocks' ? (
+                  {context.width < 1089 && publicationHandle == 'FastBlocks' ? (
                     <EmailOptIn
-                      mobile={screenWidth < 1089}
+                      mobile={context.width < 1089}
                       publictionHandle={publicationHandle}
                     />
                   ) : null}


### PR DESCRIPTION
Page widths are updated: 
Widest container size is 1328 (including sidebars)
Read article screen header image
Actual content of an article is 712 wide

Pay special attention to:
* sidebar and modal behaviors still functioning on all screens 
* Read article screen (all sizes)  
* Publication landing, specifically image widths but also general layout (all sizes) 
* Article feeds image widths (desktop) 