### PR TITLE
updated interface, environments and added migration

### DIFF
--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -55,6 +55,7 @@ actor PostCore {
   let NotPremium = "Post is not premium.";
 
   type PostModerationStatus = Types.PostModerationStatus;
+  type PostModerationStatusV2 = Types.PostModerationStatusV2;
   type Tag = Types.Tag;
   type TagModel = Types.TagModel;
   type PostTag = Types.PostTag;
@@ -106,6 +107,7 @@ actor PostCore {
   stable var viewsEntries : [(Text, Nat)] = [];
   stable var dailyViewHistory : [(Text, Nat)] = [];
   stable var postModerationStatusEntries : [(Text, PostModerationStatus)] = [];
+  stable var postModerationStatusEntriesV2 : [(Text, PostModerationStatusV2)] = [];
   stable var postVersionEntries : [(Text, Nat)] = [];
   stable var tagEntries : [(Text, Tag)] = [];
   stable var categoryEntries : [(Text, Text)] = [];
@@ -153,6 +155,7 @@ actor PostCore {
   var viewsHashMap = HashMap.fromIter<Text, Nat>(viewsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
   var dailyViewHistoryHashMap = HashMap.fromIter<Text, Nat>(dailyViewHistory.vals(), maxHashmapSize, Text.equal, Text.hash);
   var postModerationStatusMap = HashMap.fromIter<Text, PostModerationStatus>(postModerationStatusEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var postModerationStatusMapV2 = HashMap.fromIter<Text, PostModerationStatusV2>(postModerationStatusEntriesV2.vals(), maxHashmapSize, Text.equal, Text.hash);
   var postVersionMap = HashMap.fromIter<Text, Nat>(postVersionEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
   var tagsHashMap = HashMap.fromIter<Text, Tag>(tagEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
   var categoryHashMap = HashMap.fromIter<Text, Text>(categoryEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
@@ -2004,11 +2007,11 @@ actor PostCore {
                   viewsHashMap.put(postBucketReturn.postId, U.textToNat(postModel.views));
                   clapsHashMap.put(postBucketReturn.postId, U.textToNat(postModel.claps));
 
-                  //if the post doesn't have any post moderation status set, make it #reviewRequired
+                  //if the post doesn't have any post moderation status set, make it #new
                   let postIdWithVersion = getPostIdWithVersionId(postBucketReturn.postId, U.safeGet(postVersionMap, postBucketReturn.postId, 1));
-                  switch (postModerationStatusMap.get(postIdWithVersion)) {
+                  switch (postModerationStatusMapV2.get(postIdWithVersion)) {
                     case (null) {
-                      postModerationStatusMap.put(postIdWithVersion, #reviewRequired);
+                      postModerationStatusMapV2.put(postIdWithVersion, #new);
                     };
                     case (_)();
                   };
@@ -2558,9 +2561,9 @@ actor PostCore {
     let postIdWithVersion = getPostIdWithVersionId(postId, versionId);
     // On local, don't send posts to Modclub
     if (environment != "local") {
-      let _ = await MC.getModClubActor(environment).submitHtmlContent(postIdWithVersion, "<img style='max-height: 500px; max-width: 500px;' src='" # postModel.headerImage # "' />" # postModel.content, ?postModel.title, null, null);
+      let _ = await MC.getModclubActor(environment).submitHtmlContent(postIdWithVersion, "<img style='max-height: 500px; max-width: 500px;' src='" # postModel.headerImage # "' />" # postModel.content, ?postModel.title, null, null);
     };
-    postModerationStatusMap.put(postIdWithVersion, #reviewRequired);
+    postModerationStatusMapV2.put(postIdWithVersion, #new);
   };
 
   private func rejectedByModClub(postId : Text) : Bool {
@@ -2568,7 +2571,7 @@ actor PostCore {
       case (null)();
       case (?versionId) {
         let postIdWithVersion = getPostIdWithVersionId(postId, versionId);
-        switch (postModerationStatusMap.get(postIdWithVersion)) {
+        switch (postModerationStatusMapV2.get(postIdWithVersion)) {
           case (? #rejected) {
             return true;
           };
@@ -2583,12 +2586,108 @@ actor PostCore {
     postId # "_" # Nat.toText(versionId);
   };
 
-  public shared ({ caller }) func simulateModClub(postId : Text, status : PostModerationStatus) : async () {
+  public shared ({caller}) func migrateModclubInterface () : async Result.Result<Text, Text> {
+  
+  if (isAnonymous(caller)) {
+    return #err("Cannot use this method anonymously.");
+  };
+
+  if (not isAdmin(caller) and not isPlatformOperator(caller)) {
+    return #err(Unauthorized);
+  };
+
+  for (postId in postModerationStatusMap.keys()) {
+    let postModerationStatus = postModerationStatusMap.get(postId);
+    
+    if (postModerationStatus == ?#reviewRequired) {
+    postModerationStatusMapV2.put(postId, #new);
+    }
+    else if (postModerationStatus == ?#rejected) {
+      postModerationStatusMapV2.put(postId, #rejected);
+    } else {
+      postModerationStatusMapV2.put(postId, #approved);
+    };
+
+  };
+
+  return #ok("ok");
+};
+
+func toText (postModerationStatus : ?PostModerationStatus) : Text {
+  switch (postModerationStatus) {
+    case (?#approved) {
+      return "approved";
+    };
+    case (?#rejected) {
+      return "rejected";
+    };
+    case (?#reviewRequired) {
+      return "reviewRequired";
+    };
+    case (_) {
+      return "Error";
+    };
+  };
+};
+
+func toTextV2 (postModerationStatus : ?PostModerationStatusV2) : Text {
+  switch (postModerationStatus) {
+    case (?#approved) {
+      return "approved";
+    };
+    case (?#rejected) {
+      return "rejected";
+    };
+    case (?#new) {
+      return "new";
+    };
+    case (_) {
+      return "error";
+    };
+  };
+};
+
+public shared ({caller}) func getAllStatusCount () : async Result.Result<Text, Text> {
+  
+  if (isAnonymous(caller)) {
+    return #err("Cannot use this method anonymously.");
+  };
+
+  if (not isAdmin(caller) and not isPlatformOperator(caller)) {
+    return #err(Unauthorized);
+  };
+
+  var changedCount = 0;
+  var totalCount = 0;
+  
+  for (postId in postModerationStatusMap.keys()) {
+    let postModerationStatus = postModerationStatusMap.get(postId);
+    let postModerationStatusV2 = postModerationStatusMapV2.get(postId);
+    
+    Debug.print(debug_show(postId) # " " # debug_show(postModerationStatus) # " " # debug_show(postModerationStatusV2));
+    if (postModerationStatusV2 == ?#new) {
+      changedCount += 1;
+    };
+    totalCount += 1;
+
+    };
+
+  return #ok( "Total: " # debug_show(totalCount) # " Changed: " # debug_show(changedCount));
+  };
+
+
+
+
+  public shared ({ caller }) func simulateModClub(postId : Text, status : PostModerationStatusV2) : async () {
     if (isAnonymous(caller)) {
       return;
     };
 
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
+      return;
+    };
+
+    if (environment == "prod") { //No centralized moderation in prod, fine for testing in dev
       return;
     };
 
@@ -2597,7 +2696,7 @@ actor PostCore {
       case (null)();
       case (?versionId) {
         let postIdWithVersion = getPostIdWithVersionId(postId, versionId);
-        postModerationStatusMap.put(postIdWithVersion, status);
+        postModerationStatusMapV2.put(postIdWithVersion, status);
       };
     };
   };
@@ -2610,18 +2709,32 @@ actor PostCore {
     if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       Prelude.unreachable();
     };
-    ignore U.logMetrics("setupModClub", Principal.toText(caller));
+    ignore U.logMetrics("setupModClub ENV: " # env # " ", Principal.toText(caller));
 
-    if (env != "local" and env != "staging" and env != "prod") {
+    if (env != "local" and env != "dev" and env != "prod") {
       throw Error.reject("Please Provide correct environment value");
     };
-    environment := env;
+    switch (env) {
+      case ("local") {
+        environment := "local";
+      };
+      case ("staging") {
+        environment := "dev";
+      };
+      case ("prod") {
+        environment := "prod";
+      };
+      case (_) {
+        throw Error.reject("Please Provide correct environment value");
+    };
+    };
+
     // On local don't set up Modclub
     if (environment == "local") {
       return;
     };
 
-    let _ = await MC.getModClubActor(environment).registerProvider("Nuance", "Nuance", null);
+    let _ = await MC.getModclubActor(environment).registerProvider("Nuance", "Nuance", null);
     if (not modClubRulesAdded) {
       let rules = [
         "This post threatens violence against an individual or a group of people",
@@ -2644,17 +2757,17 @@ actor PostCore {
         "This post contains deceptively share synthetic or manipulated media that are likely to cause harm",
         "This post violates others’ intellectual property rights, including copyright and trademark",
       ];
-      await MC.getModClubActor(environment).addRules(rules, null);
+      await MC.getModclubActor(environment).addRules(rules, null);
       modClubRulesAdded := true;
     };
-    await MC.getModClubActor(environment).subscribe({
+    await MC.getModclubActor(environment).subscribe({
       callback = modClubCallback;
     });
   };
 
   public shared ({ caller }) func modClubCallback(postStatus : MC.ContentResult) {
-    // HardCoded ModClub Canister Prod Id
-    if (not isAdmin(caller) and (Principal.toText(caller) != MC.getModClubId(environment))) {
+
+    if (not isAdmin(caller) and (Principal.toText(caller) != MC.getModclubId(environment))) {
       Prelude.unreachable();
     };
 
@@ -2662,14 +2775,14 @@ actor PostCore {
       assert false;
     };
 
-    switch (postModerationStatusMap.get(postStatus.sourceId)) {
+    switch (postModerationStatusMapV2.get(postStatus.sourceId)) {
       case (null)();
       case (_) {
-        postModerationStatusMap.put(postStatus.sourceId, postStatus.status);
+        postModerationStatusMapV2.put(postStatus.sourceId, postStatus.status);
         let postId = getPostIdFromVersionId(postStatus.sourceId);
         let bucketCanisterId = U.safeGet(postIdsToBucketCanisterIdsHashMap, postId, "");
         let bucketActor = actor (bucketCanisterId) : BucketCanisterInterface;
-        if (postStatus.status != #approved) {
+        if (postStatus.status == #rejected) {
           //inform the bucket canister that post was rejected
           await bucketActor.rejectPostByModclub(postId);
           await removePostFromIndex(postStatus.sourceId);
@@ -2682,37 +2795,6 @@ actor PostCore {
     };
   };
 
-  public shared ({ caller }) func modClubCallbackDebug(postStatus : MC.ContentResult) : async Text {
-    // HardCoded ModClub Canister Prod Id
-    if (not isAdmin(caller) and (Principal.toText(caller) != MC.getModClubId(environment))) {
-      return "Unauthorized";
-    };
-
-    switch (postModerationStatusMap.get(postStatus.sourceId)) {
-      case (null) { "postModerationStatus not found." };
-      case (_) {
-        var result = "";
-        postModerationStatusMap.put(postStatus.sourceId, postStatus.status);
-        let postId = getPostIdFromVersionId(postStatus.sourceId);
-        let bucketCanisterId = U.safeGet(postIdsToBucketCanisterIdsHashMap, postId, "");
-        let bucketActor = actor (bucketCanisterId) : BucketCanisterInterface;
-        result #= "PostId: " # postId # " ";
-        if (postStatus.status != #approved) {
-          //inform the bucket canister that post was rejected
-          await bucketActor.rejectPostByModclub(postId);
-          await removePostFromIndex(postStatus.sourceId);
-          await generateLatestPosts();
-          result #= " called all the bucket canister methods";
-          return result;
-        } else {
-          //inform the bucket canister that post is not rejected
-          await bucketActor.unRejectPostByModclub(postId);
-          result #= " unrejected post. ";
-          return result;
-        };
-      };
-    };
-  };
 
   private func removePostFromIndex(sourceId : Text) : async () {
 
@@ -2749,28 +2831,10 @@ actor PostCore {
       Prelude.unreachable();
     };
     if (rules.size() > 0) {
-      await MC.getModClubActor(environment).addRules(rules, null);
+      await MC.getModclubActor(environment).addRules(rules, null);
     };
   };
 
-  public shared ({ caller }) func removeExistingRules(ruleIds : [Text]) : async () {
-    if (isAnonymous(caller)) {
-      return;
-    };
-    if (not isAdmin(caller)) {
-      Prelude.unreachable();
-    };
-    if (ruleIds.size() > 0) {
-      await MC.getModClubActor(environment).removeRules(ruleIds);
-    };
-  };
-
-  public shared ({ caller }) func getRegisteredRules() : async [MC.Rule] {
-    if (not isAdmin(caller)) {
-      Prelude.unreachable();
-    };
-    await MC.getModClubActor(environment).getProviderRegisteredRules();
-  };
 
   private func getPostIdFromVersionId(postIdWithVersion : Text) : Text {
     // postid & version are concatenated using postId # "_" # Nat.toText(versionId);
@@ -3736,6 +3800,7 @@ actor PostCore {
     viewsEntries := Iter.toArray(viewsHashMap.entries());
     dailyViewHistory := Iter.toArray(dailyViewHistoryHashMap.entries());
     postModerationStatusEntries := Iter.toArray(postModerationStatusMap.entries());
+    postModerationStatusEntriesV2 := Iter.toArray(postModerationStatusMapV2.entries());
     postVersionEntries := Iter.toArray(postVersionMap.entries());
     tagEntries := Iter.toArray(tagsHashMap.entries());
     categoryEntries := Iter.toArray(categoryHashMap.entries());
@@ -3777,6 +3842,7 @@ actor PostCore {
     viewsEntries := [];
     dailyViewHistory := [];
     postModerationStatusEntries := [];
+    postModerationStatusEntriesV2 := [];
     postVersionEntries := [];
     tagEntries := [];
     categoryEntries := [];

--- a/src/PostCore/modclub/modclub.mo
+++ b/src/PostCore/modclub/modclub.mo
@@ -1,50 +1,50 @@
 import Text "mo:base/Text";
 import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
+import Nat64 "mo:base/Nat64";
+import Float "mo:base/Float";
+import Result "mo:base/Result";
+import Error "mo:base/Error";
+import Principal "mo:base/Principal";
+
 
 // This is the interface to modclub for providers
-module {
+module Modclub {
 
   type ContentId = Text;
   public type ContentStatus = {
     #approved;
     #rejected;
-    #reviewRequired;
+    #new;
+  };
+
+  public type ViolatedRules = {
+    id : Text;
+    rejectionCount: Nat;
   };
 
   public type ContentResult = {
     sourceId : Text;
+    approvedCount: Nat;
+    rejectedCount: Nat;
     status : ContentStatus;
+    violatedRules: [ViolatedRules];
   };
 
   public type ProviderSettings = {
-    minVotes : Nat;
-    minStaked : Nat;
+    requiredVotes: Nat;
+    minStaked: Nat;
   };
 
   public type Image = {
-    data : [Nat8];
-    imageType : Text;
+    data: [Nat8];
+    imageType: Text;
   };
 
-  public type SubscribeMessage = { callback : shared ContentResult -> () };
+  public type SubscribeMessage = { callback: shared ContentResult -> (); };
 
-  public type PohVerificationResponse = {
-    requestId : Text;
-    providerUserId : Principal;
-    status : PohChallengeStatus;
-    // status at each challenge level
-    challenges : [ChallengeResponse];
-    providerId : Principal;
-    requestedOn : Int;
-  };
-
-  public type ChallengeResponse = {
-    challengeId : Text;
-    status : PohChallengeStatus;
-    completedOn : ?Int;
-  };
-
-  public type PohChallengeStatus = {
+  public type PohVerificationStatus = {
+    #startPoh;
     #notSubmitted;
     #pending;
     #verified;
@@ -52,13 +52,39 @@ module {
     #expired;
   };
 
-  public type PohUniqueToken = {
-    token : Text;
+  public type PohVerificationResponsePlus = {
+    providerUserId: Text;
+    status: PohVerificationStatus;
+    // status at each challenge level
+    challenges: [ChallengeResponse];
+    providerId: Principal;
+    token: ?Text;
+    rejectionReasons: [Text];
+    requestedAt: ?Int;
+    submittedAt: ?Int;
+    completedAt: ?Int;
+    isFirstAssociation: Bool;
+  };
+
+  public type SubscribePohMessage = {
+    callback: shared (PohVerificationResponsePlus) -> ();
+  };
+
+  public type ChallengeResponse = {
+    challengeId: Text;
+    status : PohChallengeStatus;
+    completedOn : ?Int;
+  };
+
+  public type PohChallengeStatus = {#notSubmitted; #pending; #verified; #rejected; #expired;};
+
+  public type PohUniqueToken =  {
+    token: Text;
   };
 
   public type Rule = {
-    id : Text;
-    description : Text;
+    id: Text;
+    description: Text;
   };
 
   public type Level = {
@@ -68,69 +94,132 @@ module {
     #xhard;
   };
 
-  public type ModClubActorType = actor {
-    registerProvider : (Text, Text, ?Image) -> async Text;
-    deregisterProvider : () -> async Text;
-    addRules : ([Text], ?Principal) -> async ();
-    removeRules : ([Text]) -> async ();
-    getProviderRegisteredRules : () -> async [Rule];
-    updateSettings : (ProviderSettings) -> async ();
-    submitText : (Text, Text, ?Text) -> async Text;
-    submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
-    subscribe : (SubscribeMessage) -> async ();
-    // Proof of Humanity APIs
-    pohVerificationRequest : (Principal) -> async PohVerificationResponse;
-    pohGenerateUniqueToken : (Principal) -> async PohUniqueToken;
+  public type Result<T, E> = { #Ok : T; #Err : E };
+  public type Account = { owner : Principal; subaccount : ?Subaccount };
+  public type Subaccount = Blob;
+  public type Tokens = Nat;
+  public type Memo = Blob;
+  public type Timestamp = Nat64;
+  public type TxIndex = Nat;
+  public type DeduplicationError = {
+    #TooOld;
+    #Duplicate : { duplicate_of : TxIndex };
+    #CreatedInFuture : { ledger_time : Timestamp };
+  };
+  public type CommonError = {
+    #InsufficientFunds : { balance : Tokens };
+    #BadFee : { expected_fee : Tokens };
+    #TemporarilyUnavailable;
+    #GenericError : { error_code : Nat; message : Text };
+  };
+  public type TransferError = DeduplicationError or CommonError or {
+    #BadBurn : { min_burn_amount : Tokens };
   };
 
+  public type ModclubActorType = actor {
+    registerProvider: (Text, Text, ?Image) -> async Text;
+    deregisterProvider: () -> async Text;
+    addRules: ([Text], ?Principal) -> async ();
+    getProviderRules: () -> async [Rule];
+    removeRules: ([Text], ?Principal) -> async ();
+    addProviderAdmin:(Principal, Text, ?Principal) -> async ();
+    removeProviderAdmin: (Principal, Principal) -> async ();
+    submitText: (Text, Text, ?Text, ?Level, ?Text) -> async Text;
+    submitImage: (Text, [Nat8], Text, ?Text, ?Level, ?Text) -> async Text;
+    submitHtmlContent: (Text, Text, ?Text, ?Level, ?Text) -> async Text;
+    subscribe: (SubscribeMessage) -> async ();
+    // Provider funds management
+    getProviderSa(Text, ?Principal) : async Blob;
+    providerSaBalance(Text, ?Principal) : async Tokens;
+    // Proof of Humanity APIs
+    verifyHumanity: (Text) -> async PohVerificationResponsePlus;
+    subscribePohCallback: (SubscribePohMessage) -> async ();
+  };
+
+  public type ModclubLedgerActorType = actor {
+    icrc1_balance_of : (Account) -> async Tokens;
+    icrc1_fee : () -> async Nat;
+    icrc1_decimals : () -> async Nat8;
+    icrc1_transfer : ({
+      from_subaccount : ?Subaccount;
+      to : Account;
+      amount : Tokens;
+      fee : ?Tokens;
+      memo : ?Memo;
+      created_at_time : ?Timestamp;
+    }) -> async Result<TxIndex, TransferError>;
+  };
+
+  public let MODCLUB_CANISTER_ID_QA = "hvyqe-cyaaa-aaaah-qdbiq-cai";
   public let MODCLUB_CANISTER_ID_DEV = "d7isk-4aaaa-aaaah-qdbsa-cai";
-  public let ModClub_DEV_ACTOR = actor "d7isk-4aaaa-aaaah-qdbsa-cai" : actor {
-    registerProvider : (Text, Text, ?Image) -> async Text;
-    deregisterProvider : () -> async Text;
-    addRules : ([Text], ?Principal) -> async ();
-    removeRules : ([Text]) -> async ();
-    getProviderRegisteredRules : () -> async [Rule];
-    updateSettings : (ProviderSettings) -> async ();
-    submitText : (Text, Text, ?Text) -> async Text;
-    submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
-    subscribe : (SubscribeMessage) -> async ();
-    // Proof of Humanity APIs
-    pohVerificationRequest : (Principal) -> async PohVerificationResponse;
-    pohGenerateUniqueToken : (Principal) -> async PohUniqueToken;
-  };
-
   public let MODCLUB_CANISTER_ID_PROD = "gwuzc-waaaa-aaaah-qdboa-cai";
-  public let ModClub_PROD_ACTOR = actor "gwuzc-waaaa-aaaah-qdboa-cai" : actor {
-    registerProvider : (Text, Text, ?Image) -> async Text;
-    deregisterProvider : () -> async Text;
-    addRules : ([Text], ?Principal) -> async ();
-    removeRules : ([Text]) -> async ();
-    getProviderRegisteredRules : () -> async [Rule];
-    updateSettings : (ProviderSettings) -> async ();
-    submitText : (Text, Text, ?Text) -> async Text;
-    submitImage : (Text, [Nat8], Text, ?Text) -> async Text;
-     submitHtmlContent : (Text, Text, ?Text, ?Level, ?Text) -> async Text;
-    subscribe : (SubscribeMessage) -> async ();
-    // Proof of Humanity APIs
-    pohVerificationRequest : (Principal) -> async PohVerificationResponse;
-    pohGenerateUniqueToken : (Principal) -> async PohUniqueToken;
-  };
 
-  public func getModClubId(environment : Text) : Text {
-    if (environment == "prod") {
-      return MODCLUB_CANISTER_ID_PROD;
-    } else {
-      return MODCLUB_CANISTER_ID_DEV;
+  public let MODCLUB_LEDGER_QA = "vckh6-hqaaa-aaaah-qc7wa-cai";
+  public let MODCLUB_LEDGER_DEV = "vxnwt-gyaaa-aaaah-qc7vq-cai";
+  public let MODCLUB_LEDGER_PROD = "xsi2v-cyaaa-aaaaq-aabfq-cai";
+
+  public func getModclubId(env: Text) : Text {
+    switch(env) {
+      case("prod") { MODCLUB_CANISTER_ID_PROD; };
+      case("dev") { MODCLUB_CANISTER_ID_DEV; };
+      case("qa") { MODCLUB_CANISTER_ID_QA; };
+      case(_) {"2vxsx-fae"}; // anonymous
     };
   };
 
-  public func getModClubActor(environment : Text) : ModClubActorType {
-    if (environment == "prod") {
-      return ModClub_PROD_ACTOR;
-    } else {
-      return ModClub_DEV_ACTOR;
+  public func getModclubLedgerId(env: Text) : Text {
+    switch(env) {
+      case("prod") { MODCLUB_LEDGER_PROD; };
+      case("dev") { MODCLUB_LEDGER_DEV; };
+      case("qa") { MODCLUB_LEDGER_QA; };
+      case(_) {"2vxsx-fae"}; // anonymous
     };
+  };
+
+  public func getModclubActor(env: Text) : ModclubActorType {
+     actor (getModclubId(env)) : ModclubActorType;
+  };
+
+  public func getModclubLedgerActor(env: Text) : ModclubLedgerActorType {
+     actor (getModclubLedgerId(env)) : ModclubLedgerActorType;
+  };
+
+  public func initProvider(env : Text, name : Text, description : Text, ?companyLogo : ?Image) : async Result.Result<Bool, Text> {
+    let modclub = getModclubActor(env);
+    let resp = await modclub.registerProvider(name, description, ?companyLogo);
+    if (Text.contains("Registration successful", #text resp) or Text.contains("already registered", #text resp)) {
+      return #ok(true);
+    };
+    if (Text.contains("not in allow list", #text resp)) {
+      return #err("Unable to register provider. Provider is not in allow list.");
+    };
+    return #err("Unable to register provider." # resp);
+  };
+
+  public func topUpReserveBalance(env : Text, amount : Tokens) : async Result<TxIndex, TransferError> {
+    let modclub = getModclubActor(env);
+    let saReserve = await modclub.getProviderSa("RESERVE", null);
+    let ledger = getModclubLedgerActor(env);
+    await ledger.icrc1_transfer({
+      from_subaccount = null;
+      to = {
+        owner = Principal.fromText(getModclubId(env));
+        subaccount = ?saReserve;
+      };
+      amount;
+      created_at_time = null;
+      fee = null;
+      memo = null;
+    });
+  };
+
+  public func providerSaBalance(env : Text) : async Tokens {
+    let modclub = getModclubActor(env);
+    let saReserve = await modclub.getProviderSa("RESERVE", null);
+    let ledger = getModclubLedgerActor(env);
+    await ledger.icrc1_balance_of({
+        owner = Principal.fromText(getModclubId(env));
+        subaccount = ?saReserve;
+    });
   };
 };

--- a/src/PostCore/types.mo
+++ b/src/PostCore/types.mo
@@ -194,7 +194,11 @@ module {
         isDraft:Bool;
     };
 
-    public type PostModerationStatus = {
+    public type PostModerationStatusV2 = {
+        #approved; #new; #rejected
+    };
+
+     public type PostModerationStatus = {
         #reviewRequired;#rejected;#approved;
     };
 

--- a/src/nuance_assets/components/clap-modal/clap-modal.tsx
+++ b/src/nuance_assets/components/clap-modal/clap-modal.tsx
@@ -174,7 +174,12 @@ export const ClapModal = (props: { post: PostType }) => {
           By applauding this article, you are tipping the writer with a fragment
           of your wallet. One clap is the equivalent of one Nuance Tokens (NUA).
           <br />
-          <span className='read-more'>Read More</span>
+          <span onClick={()=>{
+            window.open(
+              'https://wiki.nuance.xyz/nuance/how-to-tip-applaud-a-writer',
+              '_blank'
+            );
+          }} className='read-more'>Read More</span>
         </p>
         <div className='owned-tokens-wrapper'>
           <p className='clap-modal-field-text'>CURRENTLY IN YOUR WALLET</p>
@@ -475,7 +480,7 @@ export const ClapModal = (props: { post: PostType }) => {
             Close
           </Button>
           <Button
-            styleType={darkTheme ? 'withdraw-dark' : 'withdraw'}
+            styleType={ darkTheme ? 'withdraw-dark' : 'withdraw'}
             type='button'
             onClick={() => {
               window.location.href = '/my-profile/wallet'

--- a/src/nuance_assets/components/logged-out-sidebar/logged-out-sidebar.tsx
+++ b/src/nuance_assets/components/logged-out-sidebar/logged-out-sidebar.tsx
@@ -133,7 +133,7 @@ const LoggedOutSidebar: React.FC<LoggedOutSidebarProps> = (props): JSX.Element =
 
         <a
           className='logged-out-sidebar-identity'
-          href='https://smartcontracts.org/docs/ic-identity-guide/what-is-ic-identity.html'
+          href='https://internetcomputer.org/internet-identity'
           target='_blank'
           style={darkTheme ? { color: 'white' } : {}}
         >


### PR DESCRIPTION
Affected Hashmaps are appended with `V2`. We may consider a subsequent deploy once we've determined this is stable to remove unused data and return the name to the original. 

You can run the migration with `dfx canister call PostCore migrateModclubInterface`.           