### PR TITLE
removes 404

### DIFF
--- a/src/Storage/storage/buckets.mo
+++ b/src/Storage/storage/buckets.mo
@@ -211,7 +211,7 @@ actor class Bucket () = this {
     Debug.print("Sending chunk " # debug_show(token.key) # debug_show(token.index));
     let body:Blob = switch(state.chunks.get(chunkId(token.key, token.index))) {
       case (?b) b;
-      case (null) "404 Not Found";
+      case (null) Blob.fromArray([]);
     };
     let next_token:? StreamingCallbackToken = switch(state.chunks.get(chunkId(token.key, token.index+1))){
       case (?nextbody) ?{


### PR DESCRIPTION
Removes 404 from modclub dashboard, this bug appeared after we removed chunking from http requests. Some of the code checked for a second chunk, if not found it would deliver a 404. 