### PR TITLE
Added functions to add a storage canister

### DIFF
--- a/src/Storage/storage/storage.mo
+++ b/src/Storage/storage/storage.mo
@@ -115,6 +115,15 @@ public class StorageSolution(storageStableState : StorageState.DataCanisterState
       return b;
     };
 
+
+
+    public func addStorageBucket(canisterId: Principal) : async Text {
+      
+      let b = actor (Principal.toText(canisterId)) : Bucket.Bucket;
+      storageState.dataCanisters.put(canisterId, b);
+      return Principal.toText(canisterId) # " added";
+    };
+
     // canister memory is set to 4GB and compute allocation to 5 as the purpose 
     // of this canisters is mostly storage
     // set canister owners to the wallet canister and the container canister ie: this


### PR DESCRIPTION
To upgrade storage bucket:
1. Deploy changes to storage canister to prod via proposal. 
2. Paul will add storage canister and sns governance as controller of the missing storage bucket
3. delete .dfx storage bucket (if it exists) then build canister. 
4. run `node scripts/upgrades/storageBucketCanisterUpgrade.js --multi --ic`

