### PR TITLE
fix 1538

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ USERGEEK_API_KEY_SECONDARY="<usergeek-secondary-api-key-here>"
 # comment out for local development, set to "ic" for mainnet
  DFX_NETWORK="local"
 
-PUBLICATIONS_REPO_PATH=./Nuance-NFTs-and-Publications
-NUANCE_MAIN_REPO_PATH=./
+PUBLICATIONS_REPO_PATH=/Users/barolukluk/Desktop/local_env/Nuance/Nuance-NFTs-and-Publications
+NUANCE_MAIN_REPO_PATH=/Users/barolukluk/Desktop/local_env/Nuance/
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ scripts/didc
 dist/
 dist_old/
 CyclesDispenser.json
+.vessel

--- a/Nuance-NFTs-and-Publications/src/Publisher/main.mo
+++ b/Nuance-NFTs-and-Publications/src/Publisher/main.mo
@@ -99,8 +99,8 @@ actor class Publisher() = this {
     // local variables
     let canistergeekMonitor = Canistergeek.Monitor();
     func isEq(x : Text, y : Text) : Bool { x == y };
-    var maxHashmapSize = 1000000;
-    var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
+    var initCapacity = 0;
+    var hashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
     stable var index : [(Text, [Text])] = [];
 
     // publisher data types
@@ -130,30 +130,30 @@ actor class Publisher() = this {
     stable var publicationCtaIconEntries : [(Text, Text)] = [];
 
     // publisher hashmaps
-    var publicationHandleHashMap = HashMap.fromIter<Text, Text>(publicationHandleEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var publicationTitleHashMap = HashMap.fromIter<Text, Text>(publicationTitleEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var editorsHashMap = HashMap.fromIter<Text, [Text]>(editorsEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var canisterIdHashMap = HashMap.fromIter<Text, Text>(canisterIdEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var writersHashMap = HashMap.fromIter<Text, [Text]>(writersEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var headerImageHashMap = HashMap.fromIter<Text, Text>(headerImageEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var subtitleHashMap = HashMap.fromIter<Text, Text>(subtitleEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var descriptionHashMap = HashMap.fromIter<Text, Text>(descriptionEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var categoriesHashMap = HashMap.fromIter<Text, [Text]>(categoriesEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var websiteHashMap = HashMap.fromIter<Text, Text>(websiteEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var socialChannelsUrlsHashMap = HashMap.fromIter<Text, [Text]>(socialChannelUrlsEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var avatarHashMap = HashMap.fromIter<Text, Text>(avatarEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var userHandleHashmap = HashMap.fromIter<Text, Text>(canisterIdEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var createdHashMap = HashMap.fromIter<Text, Text>(createdEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var modifiedHashMap = HashMap.fromIter<Text, Text>(modifiedEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var stylingFontTypeHashmap = HashMap.fromIter<Text, Text>(stylingFontTypeEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var stylingPrimaryColorHashmap = HashMap.fromIter<Text, Text>(stylingPrimaryColorEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var brandLogoHashmap = HashMap.fromIter<Text, Text>(brandLogoEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var publicationCtaButtonCopyHashMap = HashMap.fromIter<Text, Text>(publicationCtaButtonCopyEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var publicationCtaCopyHashMap = HashMap.fromIter<Text, Text>(publicationCtaCopyEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var publicationCtaLinkHashMap = HashMap.fromIter<Text, Text>(publicationCtaLinkEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var publicationCtaIconHashMap = HashMap.fromIter<Text, Text>(publicationCtaIconEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var editorsHandlesHashmap = HashMap.fromIter<Text, [Text]>(editorsHandlesEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    var writersHandlesHashmap = HashMap.fromIter<Text, [Text]>(writersHandlesEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var publicationHandleHashMap = HashMap.fromIter<Text, Text>(publicationHandleEntries.vals(), initCapacity, isEq, Text.hash);
+    var publicationTitleHashMap = HashMap.fromIter<Text, Text>(publicationTitleEntries.vals(), initCapacity, isEq, Text.hash);
+    var editorsHashMap = HashMap.fromIter<Text, [Text]>(editorsEntries.vals(), initCapacity, isEq, Text.hash);
+    var canisterIdHashMap = HashMap.fromIter<Text, Text>(canisterIdEntries.vals(), initCapacity, isEq, Text.hash);
+    var writersHashMap = HashMap.fromIter<Text, [Text]>(writersEntries.vals(), initCapacity, isEq, Text.hash);
+    var headerImageHashMap = HashMap.fromIter<Text, Text>(headerImageEntries.vals(), initCapacity, isEq, Text.hash);
+    var subtitleHashMap = HashMap.fromIter<Text, Text>(subtitleEntries.vals(), initCapacity, isEq, Text.hash);
+    var descriptionHashMap = HashMap.fromIter<Text, Text>(descriptionEntries.vals(), initCapacity, isEq, Text.hash);
+    var categoriesHashMap = HashMap.fromIter<Text, [Text]>(categoriesEntries.vals(), initCapacity, isEq, Text.hash);
+    var websiteHashMap = HashMap.fromIter<Text, Text>(websiteEntries.vals(), initCapacity, isEq, Text.hash);
+    var socialChannelsUrlsHashMap = HashMap.fromIter<Text, [Text]>(socialChannelUrlsEntries.vals(), initCapacity, isEq, Text.hash);
+    var avatarHashMap = HashMap.fromIter<Text, Text>(avatarEntries.vals(), initCapacity, isEq, Text.hash);
+    var userHandleHashmap = HashMap.fromIter<Text, Text>(canisterIdEntries.vals(), initCapacity, isEq, Text.hash);
+    var createdHashMap = HashMap.fromIter<Text, Text>(createdEntries.vals(), initCapacity, isEq, Text.hash);
+    var modifiedHashMap = HashMap.fromIter<Text, Text>(modifiedEntries.vals(), initCapacity, isEq, Text.hash);
+    var stylingFontTypeHashmap = HashMap.fromIter<Text, Text>(stylingFontTypeEntries.vals(), initCapacity, isEq, Text.hash);
+    var stylingPrimaryColorHashmap = HashMap.fromIter<Text, Text>(stylingPrimaryColorEntries.vals(), initCapacity, isEq, Text.hash);
+    var brandLogoHashmap = HashMap.fromIter<Text, Text>(brandLogoEntries.vals(), initCapacity, isEq, Text.hash);
+    var publicationCtaButtonCopyHashMap = HashMap.fromIter<Text, Text>(publicationCtaButtonCopyEntries.vals(), initCapacity, isEq, Text.hash);
+    var publicationCtaCopyHashMap = HashMap.fromIter<Text, Text>(publicationCtaCopyEntries.vals(), initCapacity, isEq, Text.hash);
+    var publicationCtaLinkHashMap = HashMap.fromIter<Text, Text>(publicationCtaLinkEntries.vals(), initCapacity, isEq, Text.hash);
+    var publicationCtaIconHashMap = HashMap.fromIter<Text, Text>(publicationCtaIconEntries.vals(), initCapacity, isEq, Text.hash);
+    var editorsHandlesHashmap = HashMap.fromIter<Text, [Text]>(editorsHandlesEntries.vals(), initCapacity, isEq, Text.hash);
+    var writersHandlesHashmap = HashMap.fromIter<Text, [Text]>(writersHandlesEntries.vals(), initCapacity, isEq, Text.hash);
 
     //Premium article data
     stable var subaccountIndex : Nat = 1;
@@ -166,15 +166,15 @@ actor class Publisher() = this {
     stable var writerPremiumArticlePostIdsEntries : [(Text, [Text])] = [];
 
     //key: postId value: IcpPrice
-    var premiumArticlesIcpPricesHashmap = HashMap.fromIter<Text, Nat>(premiumArticlesIcpPricesEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var premiumArticlesIcpPricesHashmap = HashMap.fromIter<Text, Nat>(premiumArticlesIcpPricesEntries.vals(), initCapacity, isEq, Text.hash);
     //key: postId value: totalSupply
-    var premiumArticlesTotalSuppliesHashmap = HashMap.fromIter<Text, Nat>(premiumArticlesTotalSuppliesEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var premiumArticlesTotalSuppliesHashmap = HashMap.fromIter<Text, Nat>(premiumArticlesTotalSuppliesEntries.vals(), initCapacity, isEq, Text.hash);
     //key: postId value: AccountIdentifier
-    var premiumArticlesWriterHandlesHashmap = HashMap.fromIter<Text, Text>(premiumArticlesWriterHandlesEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var premiumArticlesWriterHandlesHashmap = HashMap.fromIter<Text, Text>(premiumArticlesWriterHandlesEntries.vals(), initCapacity, isEq, Text.hash);
     //key: postId value: AccountIdentifier
-    var premiumArticlesTokenIndexStartsHashmap = HashMap.fromIter<Text, Nat32>(premiumArticlesTokenIndexStartsEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var premiumArticlesTokenIndexStartsHashmap = HashMap.fromIter<Text, Nat32>(premiumArticlesTokenIndexStartsEntries.vals(), initCapacity, isEq, Text.hash);
     //key writer-handle, value: [postId]
-    var writerPremiumArticlePostIdsHashmap = HashMap.fromIter<Text, [Text]>(writerPremiumArticlePostIdsEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var writerPremiumArticlePostIdsHashmap = HashMap.fromIter<Text, [Text]>(writerPremiumArticlePostIdsEntries.vals(), initCapacity, isEq, Text.hash);
 
     //the address that secondary marketplace royalties goes. default to baran's terminal icp address :)
     var marketplaceRoyaltyAddress : AccountIdentifier = "f77cc353c778b02ad26974891950e4cb3ae1203e5cd8218e1b99bfc4f316d897";
@@ -1449,7 +1449,7 @@ actor class Publisher() = this {
 
         var result = Buffer.Buffer<Post>(0);
 
-        var bucketCanisterIdToPostKeyPropertiesHashmap = HashMap.HashMap<Text, List<PostKeyProperties>>(maxHashmapSize, isEq, Text.hash);
+        var bucketCanisterIdToPostKeyPropertiesHashmap = HashMap.HashMap<Text, List<PostKeyProperties>>(initCapacity, isEq, Text.hash);
 
         for (keyProperty in myPostsKeyPropertiesReturn.vals()) {
             bucketCanisterIdToPostKeyPropertiesHashmap.put(keyProperty.bucketCanisterId, List.push(keyProperty, U.safeGet(bucketCanisterIdToPostKeyPropertiesHashmap, keyProperty.bucketCanisterId, List.nil<PostKeyProperties>())));
@@ -1522,7 +1522,7 @@ actor class Publisher() = this {
 
         var result = Buffer.Buffer<Post>(0);
 
-        var bucketCanisterIdToPostKeyPropertiesHashmap = HashMap.HashMap<Text, List<PostKeyProperties>>(maxHashmapSize, isEq, Text.hash);
+        var bucketCanisterIdToPostKeyPropertiesHashmap = HashMap.HashMap<Text, List<PostKeyProperties>>(initCapacity, isEq, Text.hash);
 
         for (keyProperty in myPostsKeyPropertiesReturn.vals()) {
             bucketCanisterIdToPostKeyPropertiesHashmap.put(keyProperty.bucketCanisterId, List.push(keyProperty, U.safeGet(bucketCanisterIdToPostKeyPropertiesHashmap, keyProperty.bucketCanisterId, List.nil<PostKeyProperties>())));
@@ -2650,7 +2650,7 @@ actor class Publisher() = this {
         Debug.print("Publisher0->postupgrade: hashmap size: " # Nat.toText(index.size()));
         canistergeekMonitor.postupgrade(_canistergeekMonitorUD);
         Debug.print("Publisher0->postupgrade:Inside Canistergeek postupgrade method");
-        hashMap := HashMap.fromIter(index.vals(), maxHashmapSize, isEq, Text.hash);
+        hashMap := HashMap.fromIter(index.vals(), initCapacity, isEq, Text.hash);
         _canistergeekMonitorUD := null;
         index := [];
         publicationHandleEntries := [];

--- a/Nuance-NFTs-and-Publications/src/nft-factory/main.mo
+++ b/Nuance-NFTs-and-Publications/src/nft-factory/main.mo
@@ -17,7 +17,7 @@ import ENV "../shared/env";
 
 actor NftFactory {
 
-    var maxHashmapSize = 1000000;
+    var initCapacity = 0;
 
     stable var admins : List.List<Text> = List.nil<Text>();
     stable var platformOperators : List.List<Text> = List.nil<Text>();
@@ -25,7 +25,7 @@ actor NftFactory {
     stable var publicationCanisterIdsEntries : [(Text, Text)] = [];
 
     //key: publisher handle, value: canister id
-    var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+    var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
     private let ic : IC.Self = actor "aaaaa-aa";
 
     //whitelist the publishers to allow create NFT canisters

--- a/Nuance-NFTs-and-Publications/src/publication-management/main.mo
+++ b/Nuance-NFTs-and-Publications/src/publication-management/main.mo
@@ -24,7 +24,7 @@ import ENV "../../../src/shared/env";
 
 actor class Management() = this {
 
-    var maxHashmapSize = 1000000;
+    var initCapacity = 0;
 
     stable var admins : List.List<Text> = List.nil<Text>();
     stable var platformOperators : List.List<Text> = List.nil<Text>();
@@ -32,7 +32,7 @@ actor class Management() = this {
     stable var publicationCanisterIdsEntries : [(Text, Text)] = [];
 
     //key: publisher handle, value: canister id
-    var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+    var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
     private let ic = IC.IC;
 
     private func isAnonymous(caller : Principal) : Bool {

--- a/src/CyclesDispenser/main.mo
+++ b/src/CyclesDispenser/main.mo
@@ -19,7 +19,7 @@ import ENV "../shared/env";
 import CanisterDeclarations "../shared/CanisterDeclarations";
 
 actor CyclesDispenser {
-  let maxHashmapSize = 1000000;
+  let initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -95,18 +95,18 @@ actor CyclesDispenser {
   stable var topUpIdToCanisterBalanceAfterEntries : [(Text, Nat)] = [];
 
   //registered canister hashmaps
-  var canisterIdToMinimumAmountOfCyclesHashmap = HashMap.fromIter<Text, Nat>(canisterIdToMinimumAmountOfCyclesEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var canisterIdToTopUpAmountHashmap = HashMap.fromIter<Text, Nat>(canisterIdToTopUpAmountEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var canisterIdToBalanceHashmap = HashMap.fromIter<Text, Nat>(canisterIdToBalanceEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var canisterIdToTopUpIdsHashmap = HashMap.fromIter<Text, [Text]>(canisterIdToTopUpIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var canisterIdToIsStorageBucketHashmap = HashMap.fromIter<Text, Bool>(canisterIdToIsStorageBucketEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var canisterIdToMinimumAmountOfCyclesHashmap = HashMap.fromIter<Text, Nat>(canisterIdToMinimumAmountOfCyclesEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var canisterIdToTopUpAmountHashmap = HashMap.fromIter<Text, Nat>(canisterIdToTopUpAmountEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var canisterIdToBalanceHashmap = HashMap.fromIter<Text, Nat>(canisterIdToBalanceEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var canisterIdToTopUpIdsHashmap = HashMap.fromIter<Text, [Text]>(canisterIdToTopUpIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var canisterIdToIsStorageBucketHashmap = HashMap.fromIter<Text, Bool>(canisterIdToIsStorageBucketEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //logged top-ups hashmaps
-  var topUpIdToCanisterIdHashmap = HashMap.fromIter<Text, Text>(topUpIdToCanisterIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var topUpIdToTimeHashmap = HashMap.fromIter<Text, Int>(topUpIdToTimeEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var topUpIdToAmountHashmap = HashMap.fromIter<Text, Nat>(topUpIdToAmountEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var topUpIdToCanisterBalanceBeforeHashmap = HashMap.fromIter<Text, Nat>(topUpIdToCanisterBalanceBeforeEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var topUpIdToCanisterBalanceAfterHashmap = HashMap.fromIter<Text, Nat>(topUpIdToCanisterBalanceAfterEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var topUpIdToCanisterIdHashmap = HashMap.fromIter<Text, Text>(topUpIdToCanisterIdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var topUpIdToTimeHashmap = HashMap.fromIter<Text, Int>(topUpIdToTimeEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var topUpIdToAmountHashmap = HashMap.fromIter<Text, Nat>(topUpIdToAmountEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var topUpIdToCanisterBalanceBeforeHashmap = HashMap.fromIter<Text, Nat>(topUpIdToCanisterBalanceBeforeEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var topUpIdToCanisterBalanceAfterHashmap = HashMap.fromIter<Text, Nat>(topUpIdToCanisterBalanceAfterEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //SNS
   public type Validate = {

--- a/src/FastBlocks_EmailOptIn/main.mo
+++ b/src/FastBlocks_EmailOptIn/main.mo
@@ -26,7 +26,7 @@ actor FastBlocks_EmailOptIn {
   private func isAnonymous(caller : Principal) : Bool {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
   };
-  var maxHashmapSize = 1000000;
+  var initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -57,8 +57,8 @@ actor FastBlocks_EmailOptIn {
   stable var emailIdEntries : [(Text, Text)] = [];
 
   stable var index : [(Text, [Text])] = [];
-  var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
-  var emailIdHashMap = HashMap.fromIter<Text, Text>(emailIdEntries.vals(), maxHashmapSize, isEq, Text.hash);
+  var hashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
+  var emailIdHashMap = HashMap.fromIter<Text, Text>(emailIdEntries.vals(), initCapacity, isEq, Text.hash);
 
   private func isAdmin(caller : Principal) : Bool {
     var c = Principal.toText(caller);
@@ -201,7 +201,7 @@ actor FastBlocks_EmailOptIn {
   system func postupgrade() {
     Debug.print("EmailOptIn->postupgrade: hashmap size: " # Nat.toText(index.size()));
     Debug.print("EmailOptIn->postupgrade:Inside postupgrade method");
-    hashMap := HashMap.fromIter(index.vals(), maxHashmapSize, isEq, Text.hash);
+    hashMap := HashMap.fromIter(index.vals(), initCapacity, isEq, Text.hash);
     index := [];
   };
 };

--- a/src/KinicEndpoint/main.mo
+++ b/src/KinicEndpoint/main.mo
@@ -26,7 +26,7 @@ actor KinicEndpoint {
   // local variables
   let canistergeekMonitor = Canistergeek.Monitor();
   func isEq(x : Text, y : Text) : Bool { x == y };
-  var maxHashmapSize = 1000000;
+  var initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -59,7 +59,7 @@ actor KinicEndpoint {
   stable var kinicPrincipals : List.List<Text> = List.nil<Text>();
 
   stable var index : [(Text, [Text])] = [];
-  var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
+  var hashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
 
   private func isAnonymous(caller : Principal) : Bool {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
@@ -312,7 +312,7 @@ actor KinicEndpoint {
     Debug.print("KinicEndpoint->postupgrade: hashmap size: " # Nat.toText(index.size()));
     canistergeekMonitor.postupgrade(_canistergeekMonitorUD);
     Debug.print("KinicEndpoint->postupgrade:Inside Canistergeek postupgrade method");
-    hashMap := HashMap.fromIter(index.vals(), maxHashmapSize, isEq, Text.hash);
+    hashMap := HashMap.fromIter(index.vals(), initCapacity, isEq, Text.hash);
     _canistergeekMonitorUD := null;
     index := [];
   };

--- a/src/Metrics/main.mo
+++ b/src/Metrics/main.mo
@@ -32,7 +32,7 @@ actor Metrics {
   private func isAnonymous(caller : Principal) : Bool {
     Principal.equal(caller, Principal.fromText("2vxsx-fae"));
   };
-  var maxHashmapSize = 1000000;
+  var initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -61,7 +61,7 @@ actor Metrics {
   stable var nuanceCanisters : [Text] = [];
 
   stable var index : [(Text, [Text])] = [];
-  var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
+  var hashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
 
   public type CyclesDispenserActorType = actor {
     getAllRegisteredCanisters : () -> async [RegisteredCanister];
@@ -253,7 +253,7 @@ actor Metrics {
   };
 
   system func postupgrade() {
-    hashMap := HashMap.fromIter(index.vals(), maxHashmapSize, isEq, Text.hash);
+    hashMap := HashMap.fromIter(index.vals(), initCapacity, isEq, Text.hash);
     index := [];
   };
 };

--- a/src/PostBucket/main.mo
+++ b/src/PostBucket/main.mo
@@ -31,7 +31,7 @@ import Sonic "../shared/sonic";
 
 actor class PostBucket() = this {
   let canistergeekMonitor = Canistergeek.Monitor();
-  let maxHashmapSize = 1000000;
+  let initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -165,87 +165,87 @@ actor class PostBucket() = this {
   // in-memory state (holds object field data) - hashmaps must match entires in above stable vars and in preupgrade and postupgrade
   // HashMaps with one entry per user
   //   key: principalId, value: handle
-  var handleHashMap = HashMap.fromIter<Text, Text>(handleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var handleHashMap = HashMap.fromIter<Text, Text>(handleEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: handle, value: principalId
-  var handleReverseHashMap = HashMap.fromIter<Text, Text>(handleReverseEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var handleReverseHashMap = HashMap.fromIter<Text, Text>(handleReverseEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: principalId, value: handle(lowercase)
-  var lowercaseHandleHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var lowercaseHandleHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: handle(lowercase), value: principalId
-  var lowercaseHandleReverseHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleReverseEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var lowercaseHandleReverseHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleReverseEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: principalId, value: List<postId>
-  var userPostsHashMap = HashMap.fromIter<Text, List.List<Text>>(userPostsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var userPostsHashMap = HashMap.fromIter<Text, List.List<Text>>(userPostsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: account-id, value: handle
-  var accountIdsToHandleHashMap = HashMap.fromIter<Text, Text>(accountIdsToHandleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var accountIdsToHandleHashMap = HashMap.fromIter<Text, Text>(accountIdsToHandleEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   // HashMaps with one entry per post (key: postId)
-  var principalIdHashMap = HashMap.fromIter<Text, Text>(principalIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var titleHashMap = HashMap.fromIter<Text, Text>(titleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var subtitleHashMap = HashMap.fromIter<Text, Text>(subtitleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var headerImageHashMap = HashMap.fromIter<Text, Text>(headerImageEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var contentHashMap = HashMap.fromIter<Text, Text>(contentEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var isDraftHashMap = HashMap.fromIter<Text, Bool>(isDraftEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var createdHashMap = HashMap.fromIter<Text, Int>(createdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var modifiedHashMap = HashMap.fromIter<Text, Int>(modifiedEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var publishedDateHashMap = HashMap.fromIter<Text, Int>(publishedDateEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var creatorHashMap = HashMap.fromIter<Text, Text>(creatorEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var isPublicationHashMap = HashMap.fromIter<Text, Bool>(isPublicationEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var categoryHashMap = HashMap.fromIter<Text, Text>(categoryEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var wordCountsHashmap = HashMap.fromIter<Text, Nat>(wordCountsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var isPremiumHashMap = HashMap.fromIter<Text, Bool>(isPremiumEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var tagNamesHashMap = HashMap.fromIter<Text, [Text]>(tagNamesEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var rejectedByModclubPostIdsHashmap = HashMap.fromIter<Text, Text>(rejectedByModclubPostIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var principalIdHashMap = HashMap.fromIter<Text, Text>(principalIdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var titleHashMap = HashMap.fromIter<Text, Text>(titleEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var subtitleHashMap = HashMap.fromIter<Text, Text>(subtitleEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var headerImageHashMap = HashMap.fromIter<Text, Text>(headerImageEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var contentHashMap = HashMap.fromIter<Text, Text>(contentEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var isDraftHashMap = HashMap.fromIter<Text, Bool>(isDraftEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var createdHashMap = HashMap.fromIter<Text, Int>(createdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var modifiedHashMap = HashMap.fromIter<Text, Int>(modifiedEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var publishedDateHashMap = HashMap.fromIter<Text, Int>(publishedDateEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var creatorHashMap = HashMap.fromIter<Text, Text>(creatorEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var isPublicationHashMap = HashMap.fromIter<Text, Bool>(isPublicationEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var categoryHashMap = HashMap.fromIter<Text, Text>(categoryEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var wordCountsHashmap = HashMap.fromIter<Text, Nat>(wordCountsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var isPremiumHashMap = HashMap.fromIter<Text, Bool>(isPremiumEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var tagNamesHashMap = HashMap.fromIter<Text, [Text]>(tagNamesEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var rejectedByModclubPostIdsHashmap = HashMap.fromIter<Text, Text>(rejectedByModclubPostIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //comment hashmaps
 
   //key: postId, value: [commentId]
-  var postIdToCommentIdsHashMap = HashMap.fromIter<Text, [Text]>(postIdToCommentIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var postIdToCommentIdsHashMap = HashMap.fromIter<Text, [Text]>(postIdToCommentIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: postId, value: numberOfComments
-  var postIdToNumberOfCommentsHashMap = HashMap.fromIter<Text, Nat>(postIdToNumberOfCommentsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var postIdToNumberOfCommentsHashMap = HashMap.fromIter<Text, Nat>(postIdToNumberOfCommentsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: postId
-  var commentIdToPostIdHashMap = HashMap.fromIter<Text, Text>(commentIdToPostIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToPostIdHashMap = HashMap.fromIter<Text, Text>(commentIdToPostIdEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: principalId
-  var commentIdToUserPrincipalIdHashMap = HashMap.fromIter<Text, Text>(commentIdToUserPrincipalIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToUserPrincipalIdHashMap = HashMap.fromIter<Text, Text>(commentIdToUserPrincipalIdEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: content
-  var commentIdToContentHashMap = HashMap.fromIter<Text, Text>(commentIdToContentEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToContentHashMap = HashMap.fromIter<Text, Text>(commentIdToContentEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: createdAt
-  var commentIdToCreatedAtHashMap = HashMap.fromIter<Text, Int>(commentIdToCreatedAtEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToCreatedAtHashMap = HashMap.fromIter<Text, Int>(commentIdToCreatedAtEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: EditedAt
-  var commentIdToEditedAtHashMap = HashMap.fromIter<Text, Int>(commentIdToEditedAtEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToEditedAtHashMap = HashMap.fromIter<Text, Int>(commentIdToEditedAtEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: [upvotedPrincipalId]
-  var commentIdToUpvotedPrincipalIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToUpvotedPrincipalIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToUpvotedPrincipalIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToUpvotedPrincipalIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: [downvotedPrincipalId]
-  var commentIdToDownvotedPrincipalIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToDownvotedPrincipalIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToDownvotedPrincipalIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToDownvotedPrincipalIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: [replyCommentId] -> The replies will not be added to postIdToCommentIdsHashmap. They are mapped to the ancestor commentId
-  var commentIdToReplyCommentIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToReplyCommentIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var commentIdToReplyCommentIdsHashMap = HashMap.fromIter<Text, [Text]>(commentIdToReplyCommentIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: replyCommentId, value: commentId
-  var replyCommentIdToCommentIdHashMap = HashMap.fromIter<Text, Text>(replyCommentIdToCommentIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var replyCommentIdToCommentIdHashMap = HashMap.fromIter<Text, Text>(replyCommentIdToCommentIdEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: commentId, value: isCensored bool
-  var isCensoredHashMap = HashMap.fromIter<Text, Bool>(isCensoredEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var isCensoredHashMap = HashMap.fromIter<Text, Bool>(isCensoredEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //applaud hashmaps
   //key: postId, value: [applaudId]
-  var postIdToApplaudIdsHashMap = HashMap.fromIter<Text, [Text]>(postIdToApplaudIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var postIdToApplaudIdsHashMap = HashMap.fromIter<Text, [Text]>(postIdToApplaudIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: principalId, value: [applaudId]
-  var principalIdToApplaudIdsHashMap = HashMap.fromIter<Text, [Text]>(principalIdToApplaudIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var principalIdToApplaudIdsHashMap = HashMap.fromIter<Text, [Text]>(principalIdToApplaudIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: principalId
-  var applaudIdToSenderHashMap = HashMap.fromIter<Text, Text>(applaudIdToSenderEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToSenderHashMap = HashMap.fromIter<Text, Text>(applaudIdToSenderEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: principalId
-  var applaudIdToReceiverHashMap = HashMap.fromIter<Text, Text>(applaudIdToReceiverEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToReceiverHashMap = HashMap.fromIter<Text, Text>(applaudIdToReceiverEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: postId
-  var applaudIdToPostIdHashMap = HashMap.fromIter<Text, Text>(applaudIdToPostIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToPostIdHashMap = HashMap.fromIter<Text, Text>(applaudIdToPostIdEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: currency (NUA, ICP, ckBTC)
-  var applaudIdToCurrencyHashMap = HashMap.fromIter<Text, Text>(applaudIdToCurrencyEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToCurrencyHashMap = HashMap.fromIter<Text, Text>(applaudIdToCurrencyEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: tokenAmount (e8s)
-  var applaudIdToTokenAmountHashMap = HashMap.fromIter<Text, Nat>(applaudIdToTokenAmountEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToTokenAmountHashMap = HashMap.fromIter<Text, Nat>(applaudIdToTokenAmountEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: receivedTokenAmount (e8s)
-  var applaudIdToReceivedTokenAmountHashMap = HashMap.fromIter<Text, Nat>(applaudIdToReceivedTokenAmountEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToReceivedTokenAmountHashMap = HashMap.fromIter<Text, Nat>(applaudIdToReceivedTokenAmountEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: number of applauds
-  var applaudIdToNumberOfApplaudsHashMap = HashMap.fromIter<Text, Nat>(applaudIdToNumberOfApplaudsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToNumberOfApplaudsHashMap = HashMap.fromIter<Text, Nat>(applaudIdToNumberOfApplaudsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: applaudId, value: date
-  var applaudIdToDateHashMap = HashMap.fromIter<Text, Int>(applaudIdToDateEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var applaudIdToDateHashMap = HashMap.fromIter<Text, Int>(applaudIdToDateEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //key: pub-handle, value: nft canister id
-  var nftCanisterIdsHashmap = HashMap.fromIter<Text, Text>(nftCanisterIds.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var nftCanisterIdsHashmap = HashMap.fromIter<Text, Text>(nftCanisterIds.vals(), initCapacity, Text.equal, Text.hash);
 
   //SNS
   public type Validate = {
@@ -1503,7 +1503,7 @@ actor class PostBucket() = this {
       return #err(Unauthorized)
     };
     //key: creatorHandle(lowercase), value: postIds
-    var creatorToPostIdsHashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, Text.equal, Text.hash);
+    var creatorToPostIdsHashMap = HashMap.HashMap<Text, [Text]>(initCapacity, Text.equal, Text.hash);
     for((postId, isPublication) in isPublicationHashMap.entries()){
       if(isPublication and U.safeGet(isDraftHashMap, postId, false)){
         //draft publication post
@@ -1519,7 +1519,7 @@ actor class PostBucket() = this {
     let userCanister = CanisterDeclarations.getUserCanister();
     let creatorUserListItems = await userCanister.getUsersByHandles(Iter.toArray(creatorToPostIdsHashMap.keys()));
     //key: creator handle (lowercase), value: principal id
-    var creatorHandleToPrincipalIdsHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, Text.equal, Text.hash);
+    var creatorHandleToPrincipalIdsHashMap = HashMap.HashMap<Text, Text>(initCapacity, Text.equal, Text.hash);
     for(creatorUserListItem in creatorUserListItems.vals()){
       creatorHandleToPrincipalIdsHashMap.put(U.lowerCase(creatorUserListItem.handle), creatorUserListItem.principal);
     };

--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -39,7 +39,7 @@ import Sonic "../shared/sonic";
 actor PostCore {
 
   let canistergeekMonitor = Canistergeek.Monitor();
-  let maxHashmapSize = 1000000;
+  let initCapacity = 0;
 
   // error messages
   let Unauthorized = "Unauthorized";
@@ -135,53 +135,53 @@ actor PostCore {
 
 
   //   key: bucket canister id, value: first post id of the bucket canister
-  var bucketCanisterIdsHashMap = HashMap.fromIter<Text, Text>(bucketCanisterIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var bucketCanisterIdsHashMap = HashMap.fromIter<Text, Text>(bucketCanisterIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: principalId, value: handle
-  var handleHashMap = HashMap.fromIter<Text, Text>(handleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var handleHashMap = HashMap.fromIter<Text, Text>(handleEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: handle, value: principalId
-  var handleReverseHashMap = HashMap.fromIter<Text, Text>(handleReverseEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var handleReverseHashMap = HashMap.fromIter<Text, Text>(handleReverseEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: principalId, value: handle(lowercase)
-  var lowercaseHandleHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var lowercaseHandleHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: handle(lowercase), value: principalId
-  var lowercaseHandleReverseHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleReverseEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var lowercaseHandleReverseHashMap = HashMap.fromIter<Text, Text>(lowercaseHandleReverseEntries.vals(), initCapacity, Text.equal, Text.hash);
   //   key: principalId, value: List<postId>
-  var userPostsHashMap = HashMap.fromIter<Text, List.List<Text>>(userPostsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var userPostsHashMap = HashMap.fromIter<Text, List.List<Text>>(userPostsEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //post data
   //key: postId, value: corresponding value
-  var postIdsToBucketCanisterIdsHashMap = HashMap.fromIter<Text, Text>(postIdsToBucketCanisterIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var principalIdHashMap = HashMap.fromIter<Text, Text>(principalIdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var createdHashMap = HashMap.fromIter<Text, Int>(createdEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var modifiedHashMap = HashMap.fromIter<Text, Int>(modifiedEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var isDraftHashMap = HashMap.fromIter<Text, Bool>(isDraftEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var publishedDateHashMap = HashMap.fromIter<Text, Int>(publishedDateEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var latestPostsHashmap = HashMap.fromIter<Text, Text>(latestPostsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var viewsHashMap = HashMap.fromIter<Text, Nat>(viewsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var dailyViewHistoryHashMap = HashMap.fromIter<Text, Nat>(dailyViewHistory.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var postModerationStatusMap = HashMap.fromIter<Text, PostModerationStatus>(postModerationStatusEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var postModerationStatusMapV2 = HashMap.fromIter<Text, PostModerationStatusV2>(postModerationStatusEntriesV2.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var postVersionMap = HashMap.fromIter<Text, Nat>(postVersionEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var tagsHashMap = HashMap.fromIter<Text, Tag>(tagEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var categoryHashMap = HashMap.fromIter<Text, Text>(categoryEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var relationships = HashMap.fromIter<Text, [PostTag]>(relationshipEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var userTagRelationships = HashMap.fromIter<Text, [PostTag]>(userTagRelationshipEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var clapsHashMap = HashMap.fromIter<Text, Nat>(clapsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var applaudsHashMap = HashMap.fromIter<Text, Nat>(applaudsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var popularityHashMap = HashMap.fromIter<Text, Nat>(popularity.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var popularityTodayHashMap = HashMap.fromIter<Text, Nat>(popularityToday.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var popularityThisWeekHashMap = HashMap.fromIter<Text, Nat>(popularityThisWeek.vals(), maxHashmapSize, Text.equal, Text.hash);
-  var popularityThisMonthHashMap = HashMap.fromIter<Text, Nat>(popularityThisMonth.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var postIdsToBucketCanisterIdsHashMap = HashMap.fromIter<Text, Text>(postIdsToBucketCanisterIdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var principalIdHashMap = HashMap.fromIter<Text, Text>(principalIdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var createdHashMap = HashMap.fromIter<Text, Int>(createdEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var modifiedHashMap = HashMap.fromIter<Text, Int>(modifiedEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var isDraftHashMap = HashMap.fromIter<Text, Bool>(isDraftEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var publishedDateHashMap = HashMap.fromIter<Text, Int>(publishedDateEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var latestPostsHashmap = HashMap.fromIter<Text, Text>(latestPostsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var viewsHashMap = HashMap.fromIter<Text, Nat>(viewsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var dailyViewHistoryHashMap = HashMap.fromIter<Text, Nat>(dailyViewHistory.vals(), initCapacity, Text.equal, Text.hash);
+  var postModerationStatusMap = HashMap.fromIter<Text, PostModerationStatus>(postModerationStatusEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var postModerationStatusMapV2 = HashMap.fromIter<Text, PostModerationStatusV2>(postModerationStatusEntriesV2.vals(), initCapacity, Text.equal, Text.hash);
+  var postVersionMap = HashMap.fromIter<Text, Nat>(postVersionEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var tagsHashMap = HashMap.fromIter<Text, Tag>(tagEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var categoryHashMap = HashMap.fromIter<Text, Text>(categoryEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var relationships = HashMap.fromIter<Text, [PostTag]>(relationshipEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var userTagRelationships = HashMap.fromIter<Text, [PostTag]>(userTagRelationshipEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var clapsHashMap = HashMap.fromIter<Text, Nat>(clapsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var applaudsHashMap = HashMap.fromIter<Text, Nat>(applaudsEntries.vals(), initCapacity, Text.equal, Text.hash);
+  var popularityHashMap = HashMap.fromIter<Text, Nat>(popularity.vals(), initCapacity, Text.equal, Text.hash);
+  var popularityTodayHashMap = HashMap.fromIter<Text, Nat>(popularityToday.vals(), initCapacity, Text.equal, Text.hash);
+  var popularityThisWeekHashMap = HashMap.fromIter<Text, Nat>(popularityThisWeek.vals(), initCapacity, Text.equal, Text.hash);
+  var popularityThisMonthHashMap = HashMap.fromIter<Text, Nat>(popularityThisMonth.vals(), initCapacity, Text.equal, Text.hash);
 
   //key: pub-handle, value: nft canister id
-  var nftCanisterIdsHashmap = HashMap.fromIter<Text, Text>(nftCanisterIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var nftCanisterIdsHashmap = HashMap.fromIter<Text, Text>(nftCanisterIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //key: pub-handle, value: publication canister id
-  var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var publicationCanisterIdsHashmap = HashMap.fromIter<Text, Text>(publicationCanisterIdsEntries.vals(), initCapacity, Text.equal, Text.hash);
 
   //key: publication canister id, value:  editor principal ids
-  var publicationEditorsHashmap = HashMap.fromIter<Text, [Text]>(publicationEditorsEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var publicationEditorsHashmap = HashMap.fromIter<Text, [Text]>(publicationEditorsEntries.vals(), initCapacity, Text.equal, Text.hash);
   //key: publication canister id, value: writer principal ids
-  var publicationWritersHashmap = HashMap.fromIter<Text, [Text]>(publicationWritersEntries.vals(), maxHashmapSize, Text.equal, Text.hash);
+  var publicationWritersHashmap = HashMap.fromIter<Text, [Text]>(publicationWritersEntries.vals(), initCapacity, Text.equal, Text.hash);
 
 
 
@@ -2275,8 +2275,8 @@ actor PostCore {
 
     switch (await oldPostCanister.getAllModerationStatus()) {
       case (#ok(values)) {
-        postVersionMap := HashMap.fromIter<Text, Nat>(Iter.fromArray(values.0), maxHashmapSize, Text.equal, Text.hash);
-        postModerationStatusMap := HashMap.fromIter<Text, PostModerationStatus>(Iter.fromArray(values.1), maxHashmapSize, Text.equal, Text.hash);
+        postVersionMap := HashMap.fromIter<Text, Nat>(Iter.fromArray(values.0), initCapacity, Text.equal, Text.hash);
+        postModerationStatusMap := HashMap.fromIter<Text, PostModerationStatus>(Iter.fromArray(values.1), initCapacity, Text.equal, Text.hash);
         return #ok("Success");
 
       };
@@ -2744,7 +2744,7 @@ actor PostCore {
       getPublishers : () -> async [(Text, Text)];
     };
     let publishers = await publicationManagementCanister.getPublishers();
-    publicationCanisterIdsHashmap := HashMap.fromIter<Text, Text>(Iter.fromArray(publishers), maxHashmapSize, Text.equal, Text.hash);
+    publicationCanisterIdsHashmap := HashMap.fromIter<Text, Text>(Iter.fromArray(publishers), initCapacity, Text.equal, Text.hash);
     #ok(Iter.toArray(publicationCanisterIdsHashmap.entries()));
   };
 
@@ -3888,7 +3888,7 @@ public shared ({caller}) func getAllStatusCount () : async Result.Result<Text, T
 
     };
 
-    var hourlyCreatedHashmap = HashMap.HashMap<Int, Nat>(maxHashmapSize, Int.equal, Int.hash);
+    var hourlyCreatedHashmap = HashMap.HashMap<Int, Nat>(initCapacity, Int.equal, Int.hash);
 
     for ((postId, created) in last24HoursPostsCreatedTimes.vals()) {
       let hour = (created - dayThreshold) / HOUR;

--- a/src/PostIndex/main.mo
+++ b/src/PostIndex/main.mo
@@ -25,7 +25,7 @@ actor PostIndex {
   let PostIdRequired = "PostIdRequired";
   let canistergeekMonitor = Canistergeek.Monitor();
 
-  var maxHashmapSize = 1000000;
+  var initCapacity = 0;
   type List<T> = List.List<T>;
 
   //See: https://forum.dfinity.org/t/motoko-multiple-canister-imports-compile-error/10491
@@ -37,7 +37,7 @@ actor PostIndex {
   stable var _canistergeekMonitorUD : ?Canistergeek.UpgradeData = null;
   func isEq(x : Text, y : Text) : Bool { x == y };
 
-  var hashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
+  var hashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
 
   //SNS
   public type Validate = {
@@ -607,7 +607,7 @@ actor PostIndex {
     };
 
     let wordCount : Nat = hashMap.size();
-    hashMap := HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
+    hashMap := HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
 
     Debug.print("PostIndex->clearIndex: Cleared " # Nat.toText(wordCount) # " words from the index");
 
@@ -709,7 +709,7 @@ actor PostIndex {
     canistergeekMonitor.postupgrade(_canistergeekMonitorUD);
     _canistergeekMonitorUD := null;
     Debug.print("PostIndex->postupgrade:Inside Canistergeek postupgrade method");
-    hashMap := HashMap.fromIter(index.vals(), maxHashmapSize, isEq, Text.hash);
+    hashMap := HashMap.fromIter(index.vals(), initCapacity, isEq, Text.hash);
     index := [];
   };
 

--- a/src/Storage/main.mo
+++ b/src/Storage/main.mo
@@ -27,11 +27,11 @@ shared ({caller = initializer}) actor class Storage () = this {
     let Unauthorized = "Unauthorized";
     private let ic : IC.Self = actor "aaaaa-aa";
     stable var globalIdMapEntries: [(Text, Nat)] = [];
-    let maxHashmapSize = 1000000;
+    let initCapacity = 0;
     func isEq(x: Text, y: Text): Bool { x == y };
 
     //var globalIdMap = HashMap.HashMap<Text, Nat>(5000, Text.equal, Text.hash);
-    var globalIdMap = HashMap.fromIter<Text, Nat>(globalIdMapEntries.vals(), maxHashmapSize, isEq, Text.hash);
+    var globalIdMap = HashMap.fromIter<Text, Nat>(globalIdMapEntries.vals(), initCapacity, isEq, Text.hash);
 
     
 

--- a/src/User/main.mo
+++ b/src/User/main.mo
@@ -50,7 +50,7 @@ actor User {
 
   type List<T> = List.List<T>;
 
-  var maxHashmapSize = 1000000;
+  var initCapacity = 0;
 
   stable var userCount : Nat = 0;
   stable var userId : Nat = 0;
@@ -81,35 +81,35 @@ actor User {
 
   func isEq(x : Text, y : Text) : Bool { x == y };
 
-  var principalIdHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var handleHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var handleReverseHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var lowercaseHandleHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var lowercaseHandleReverseHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var displayNameHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var avatarHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var bioHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var accountCreatedHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var followersHashMap = HashMap.HashMap<Text, Followers>(maxHashmapSize, isEq, Text.hash);
-  var followersArrayHashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
-  var followersCountsHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var websiteHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var socialChannelsHashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
-  var publicationsArrayHashMap = HashMap.HashMap<Text, [PublicationObject]>(maxHashmapSize, isEq, Text.hash);
-  var nuaTokensHashMap = HashMap.HashMap<Text, Float>(maxHashmapSize, isEq, Text.hash);
-  var fontTypesHashmap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
-  var myFollowersHashMap = HashMap.HashMap<Text, [Text]>(maxHashmapSize, isEq, Text.hash);
-  var lastLoginsHashMap = HashMap.HashMap<Text, Int>(maxHashmapSize, isEq, Text.hash);
+  var principalIdHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var handleHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var handleReverseHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var lowercaseHandleHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var lowercaseHandleReverseHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var displayNameHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var avatarHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var bioHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var accountCreatedHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var followersHashMap = HashMap.HashMap<Text, Followers>(initCapacity, isEq, Text.hash);
+  var followersArrayHashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
+  var followersCountsHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var websiteHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var socialChannelsHashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
+  var publicationsArrayHashMap = HashMap.HashMap<Text, [PublicationObject]>(initCapacity, isEq, Text.hash);
+  var nuaTokensHashMap = HashMap.HashMap<Text, Float>(initCapacity, isEq, Text.hash);
+  var fontTypesHashmap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
+  var myFollowersHashMap = HashMap.HashMap<Text, [Text]>(initCapacity, isEq, Text.hash);
+  var lastLoginsHashMap = HashMap.HashMap<Text, Int>(initCapacity, isEq, Text.hash);
 
   //nft canister ids mapped to publication handles (this can extend to regular user handles when we have nft feature for regular users too)
 
   stable var nftCanisterIds : [(Text, Text)] = [];
-  var nftCanisterIdsHashmap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
+  var nftCanisterIdsHashmap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
 
   //0th account-id of user's principal mapped to user's handle
   //key: account-id, value: handle
   stable var accountIdsToHandleEntries : [(Text, Text)] = [];
-  var accountIdsToHandleHashMap = HashMap.HashMap<Text, Text>(maxHashmapSize, isEq, Text.hash);
+  var accountIdsToHandleHashMap = HashMap.HashMap<Text, Text>(initCapacity, isEq, Text.hash);
 
   //SNS
   public type Validate = {
@@ -1836,27 +1836,27 @@ actor User {
     canistergeekMonitor.postupgrade(_canistergeekMonitorUD);
     _canistergeekMonitorUD := null;
     Debug.print("User->postupgrade: Inside Canistergeek postupgrade method");
-    principalIdHashMap := HashMap.fromIter(principalId.vals(), maxHashmapSize, isEq, Text.hash);
-    handleHashMap := HashMap.fromIter(handle.vals(), maxHashmapSize, isEq, Text.hash);
-    handleReverseHashMap := HashMap.fromIter(handleReverse.vals(), maxHashmapSize, isEq, Text.hash);
-    lowercaseHandleHashMap := HashMap.fromIter(lowercaseHandle.vals(), maxHashmapSize, isEq, Text.hash);
-    lowercaseHandleReverseHashMap := HashMap.fromIter(lowercaseHandleReverse.vals(), maxHashmapSize, isEq, Text.hash);
-    displayNameHashMap := HashMap.fromIter(displayName.vals(), maxHashmapSize, isEq, Text.hash);
-    bioHashMap := HashMap.fromIter(bio.vals(), maxHashmapSize, isEq, Text.hash);
-    accountCreatedHashMap := HashMap.fromIter(accountCreatedStable.vals(), maxHashmapSize, isEq, Text.hash);
-    avatarHashMap := HashMap.fromIter(avatar.vals(), maxHashmapSize, isEq, Text.hash);
-    followersHashMap := HashMap.fromIter(followers.vals(), maxHashmapSize, isEq, Text.hash);
-    followersArrayHashMap := HashMap.fromIter(followersArray.vals(), maxHashmapSize, isEq, Text.hash);
-    followersCountsHashMap := HashMap.fromIter(followersCounts.vals(), maxHashmapSize, isEq, Text.hash);
-    publicationsArrayHashMap := HashMap.fromIter(publicationsArray.vals(), maxHashmapSize, isEq, Text.hash);
-    websiteHashMap := HashMap.fromIter(website.vals(), maxHashmapSize, isEq, Text.hash);
-    socialChannelsHashMap := HashMap.fromIter(socialChannels.vals(), maxHashmapSize, isEq, Text.hash);
-    nuaTokensHashMap := HashMap.fromIter(nuaTokens.vals(), maxHashmapSize, isEq, Text.hash);
-    fontTypesHashmap := HashMap.fromIter(fontTypes.vals(), maxHashmapSize, isEq, Text.hash);
-    nftCanisterIdsHashmap := HashMap.fromIter(nftCanisterIds.vals(), maxHashmapSize, isEq, Text.hash);
-    accountIdsToHandleHashMap := HashMap.fromIter(accountIdsToHandleEntries.vals(), maxHashmapSize, isEq, Text.hash);
-    myFollowersHashMap := HashMap.fromIter(myFollowers.vals(), maxHashmapSize, isEq, Text.hash);
-    lastLoginsHashMap := HashMap.fromIter(lastLogins.vals(), maxHashmapSize, isEq, Text.hash);
+    principalIdHashMap := HashMap.fromIter(principalId.vals(), initCapacity, isEq, Text.hash);
+    handleHashMap := HashMap.fromIter(handle.vals(), initCapacity, isEq, Text.hash);
+    handleReverseHashMap := HashMap.fromIter(handleReverse.vals(), initCapacity, isEq, Text.hash);
+    lowercaseHandleHashMap := HashMap.fromIter(lowercaseHandle.vals(), initCapacity, isEq, Text.hash);
+    lowercaseHandleReverseHashMap := HashMap.fromIter(lowercaseHandleReverse.vals(), initCapacity, isEq, Text.hash);
+    displayNameHashMap := HashMap.fromIter(displayName.vals(), initCapacity, isEq, Text.hash);
+    bioHashMap := HashMap.fromIter(bio.vals(), initCapacity, isEq, Text.hash);
+    accountCreatedHashMap := HashMap.fromIter(accountCreatedStable.vals(), initCapacity, isEq, Text.hash);
+    avatarHashMap := HashMap.fromIter(avatar.vals(), initCapacity, isEq, Text.hash);
+    followersHashMap := HashMap.fromIter(followers.vals(), initCapacity, isEq, Text.hash);
+    followersArrayHashMap := HashMap.fromIter(followersArray.vals(), initCapacity, isEq, Text.hash);
+    followersCountsHashMap := HashMap.fromIter(followersCounts.vals(), initCapacity, isEq, Text.hash);
+    publicationsArrayHashMap := HashMap.fromIter(publicationsArray.vals(), initCapacity, isEq, Text.hash);
+    websiteHashMap := HashMap.fromIter(website.vals(), initCapacity, isEq, Text.hash);
+    socialChannelsHashMap := HashMap.fromIter(socialChannels.vals(), initCapacity, isEq, Text.hash);
+    nuaTokensHashMap := HashMap.fromIter(nuaTokens.vals(), initCapacity, isEq, Text.hash);
+    fontTypesHashmap := HashMap.fromIter(fontTypes.vals(), initCapacity, isEq, Text.hash);
+    nftCanisterIdsHashmap := HashMap.fromIter(nftCanisterIds.vals(), initCapacity, isEq, Text.hash);
+    accountIdsToHandleHashMap := HashMap.fromIter(accountIdsToHandleEntries.vals(), initCapacity, isEq, Text.hash);
+    myFollowersHashMap := HashMap.fromIter(myFollowers.vals(), initCapacity, isEq, Text.hash);
+    lastLoginsHashMap := HashMap.fromIter(lastLogins.vals(), initCapacity, isEq, Text.hash);
 
     principalId := [];
     handle := [];

--- a/vessel.dhall
+++ b/vessel.dhall
@@ -1,0 +1,4 @@
+{
+  dependencies = [ "base", "matchers" ],
+  compiler = None Text
+}


### PR DESCRIPTION
Renamed the variable named maxHashMapSize to initCapacity and set it as 0 in all canisters.

You can check the effect of this fix by calling the getMemorySize method in any canister before and after the upgrade. In the PostBucket canister, it was returning 170655744 before the upgrade. After the upgrade, it returns 2555904. Which is equal to 1.4% of the old value 🤯