### PR TITLE
need platform operator access to urls to build sitemaps

### DIFF
--- a/src/PostCore/main.mo
+++ b/src/PostCore/main.mo
@@ -637,7 +637,7 @@ actor PostCore {
     };
 
     canistergeekMonitor.collectMetrics();
-    if (not isAdmin(caller)) {
+    if (not isAdmin(caller) and not isPlatformOperator(caller)) {
       return #err(Unauthorized);
     };
     var postUrls : Text = "";


### PR DESCRIPTION
To build a sitemap, we need to gather urls from all articles, currently this is trapped behind an isAdmin call. This is redundant, because if we want to have sitemaps, we need to publish our urls anyway. 