### PR TITLE
fix: resolve BigInt conversion error in ICP withdrawal

### DIFF
--- a/src/nuance_assets/components/withdraw-modal/withdraw-modal.tsx
+++ b/src/nuance_assets/components/withdraw-modal/withdraw-modal.tsx
@@ -163,9 +163,10 @@ export const WithdrawModal = () => {
     setLoading(true);
     try {
       if (selectedCurrency === 'ICP') {
-        let e8s =
+        let e8s = Math.round(
           Math.pow(10, getSelectedCurrencyBalance().token.decimals) *
-          parseFloat(inputAmount);
+          parseFloat(inputAmount)
+        );
         let response = await transferIcp(BigInt(e8s), inputAddressValue);
         if ('Ok' in response) {
           toast('Tokens transferred successfully', ToastType.Success);


### PR DESCRIPTION
Fixed floating-point precision issue when converting ICP amounts to e8s units. Added Math.round() to ensure integer values before BigInt conversion.

Resolves error: "the number 1550999.999998 cannot be converted to a Bigint because it is not an integer" when withdrawing decimal ICP amounts.

🤖 Generated with [Claude Code](https://claude.ai/code)